### PR TITLE
feat: Entry Templates (guided journal prompts)

### DIFF
--- a/src/components/TemplatePicker/TemplatePicker.scss
+++ b/src/components/TemplatePicker/TemplatePicker.scss
@@ -1,0 +1,99 @@
+@use '../../styles/_variables' as *;
+@use '../../styles/_responsive' as *;
+
+.template-picker {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  .step-header {
+    text-align: center;
+    margin-bottom: var(--spacing-lg);
+
+    .question {
+      font-size: var(--font-size-lg);
+      font-weight: var(--font-weight-bold);
+      color: var(--c-text-on-dark);
+      margin: 0 0 var(--spacing-xs) 0;
+      line-height: var(--line-height-tight);
+
+      @media (min-width: 768px) {
+        font-size: var(--font-size-xl);
+      }
+    }
+
+    .instruction {
+      font-size: var(--font-size-xs);
+      color: var(--c-text-muted-on-dark);
+      font-weight: var(--font-weight-medium);
+      margin: 0;
+    }
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    gap: var(--spacing-sm);
+
+    @media (min-width: 480px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  .template-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: var(--spacing-md);
+    background: color-mix(in srgb, var(--c-white), transparent 94%);
+    border: 1px solid var(--c-border-dark);
+    border-radius: var(--border-radius-lg);
+    cursor: pointer;
+    transition: all var(--transition-normal);
+    min-height: 96px;
+    font-family: inherit;
+
+    &:hover {
+      transform: translateY(-2px);
+      background: color-mix(in srgb, var(--c-white), transparent 88%);
+      border-color: color-mix(in srgb, var(--c-white), transparent 70%);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+
+    &.selected {
+      background: color-mix(in srgb, var(--c-secondary), transparent 85%);
+      border-color: var(--c-secondary);
+      box-shadow: 0 0 12px color-mix(in srgb, var(--c-secondary), transparent 70%);
+      transform: translateY(-2px);
+    }
+
+    &__icon {
+      font-size: 24px;
+      margin-bottom: var(--spacing-xs);
+      line-height: 1;
+
+      @media (min-width: 768px) {
+        font-size: 28px;
+      }
+    }
+
+    &__label {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      color: var(--c-text-on-dark);
+      line-height: 1.2;
+      margin-bottom: 4px;
+    }
+
+    &__description {
+      font-size: var(--font-size-xs);
+      color: var(--c-text-muted-on-dark);
+      line-height: 1.3;
+    }
+  }
+}

--- a/src/components/TemplatePicker/TemplatePicker.tsx
+++ b/src/components/TemplatePicker/TemplatePicker.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ENTRY_TEMPLATES } from '../../models/entryTemplate';
+import './TemplatePicker.scss';
+
+interface TemplatePickerProps {
+  selectedTemplateKey: string | null;
+  onSelect: (templateKey: string | null) => void;
+}
+
+const TemplatePicker: React.FC<TemplatePickerProps> = ({
+  selectedTemplateKey,
+  onSelect
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="template-picker">
+      <div className="step-header">
+        <h2 className="question">{t('entryTemplates.picker.heading')}</h2>
+        <p className="instruction">{t('entryTemplates.picker.subheading')}</p>
+      </div>
+
+      <div className="template-picker__grid">
+        <button
+          type="button"
+          className={`template-card ${selectedTemplateKey === null ? 'selected' : ''}`}
+          onClick={() => onSelect(null)}
+        >
+          <div className="template-card__icon">✍️</div>
+          <span className="template-card__label">{t('entryTemplates.freeform.label')}</span>
+          <span className="template-card__description">{t('entryTemplates.freeform.description')}</span>
+        </button>
+
+        {ENTRY_TEMPLATES.map((template) => (
+          <button
+            type="button"
+            key={template.key}
+            className={`template-card ${selectedTemplateKey === template.key ? 'selected' : ''}`}
+            onClick={() => onSelect(template.key)}
+          >
+            <div className="template-card__icon">{template.icon}</div>
+            <span className="template-card__label">{t(template.labelKey)}</span>
+            <span className="template-card__description">{t(template.descriptionKey)}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TemplatePicker;

--- a/src/components/TemplatePicker/__tests__/TemplatePicker.test.tsx
+++ b/src/components/TemplatePicker/__tests__/TemplatePicker.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TemplatePicker from '../TemplatePicker';
+import { EntryTemplateKey } from '../../../models/entryTemplate';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('TemplatePicker', () => {
+  it('should render the freeform option plus all 3 default templates', () => {
+    render(<TemplatePicker selectedTemplateKey={null} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('entryTemplates.freeform.label')).toBeInTheDocument();
+    expect(screen.getByText('entryTemplates.templates.difficult_conversation.label')).toBeInTheDocument();
+    expect(screen.getByText('entryTemplates.templates.energy_drain.label')).toBeInTheDocument();
+    expect(screen.getByText('entryTemplates.templates.gratitude_win.label')).toBeInTheDocument();
+  });
+
+  it('should mark the selected template as selected', () => {
+    render(
+      <TemplatePicker
+        selectedTemplateKey={EntryTemplateKey.ENERGY_DRAIN}
+        onSelect={vi.fn()}
+      />
+    );
+
+    const selectedCard = screen.getByText('entryTemplates.templates.energy_drain.label').closest('button');
+    expect(selectedCard).toHaveClass('selected');
+  });
+
+  it('should mark freeform as selected when no template key is selected', () => {
+    render(<TemplatePicker selectedTemplateKey={null} onSelect={vi.fn()} />);
+
+    const freeformCard = screen.getByText('entryTemplates.freeform.label').closest('button');
+    expect(freeformCard).toHaveClass('selected');
+  });
+
+  it('should call onSelect with the template key when a template card is clicked', () => {
+    const onSelect = vi.fn();
+    render(<TemplatePicker selectedTemplateKey={null} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText('entryTemplates.templates.gratitude_win.label'));
+
+    expect(onSelect).toHaveBeenCalledWith(EntryTemplateKey.GRATITUDE_WIN);
+  });
+
+  it('should call onSelect with null when the freeform card is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <TemplatePicker
+        selectedTemplateKey={EntryTemplateKey.DIFFICULT_CONVERSATION}
+        onSelect={onSelect}
+      />
+    );
+
+    fireEvent.click(screen.getByText('entryTemplates.freeform.label'));
+
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,6 +148,49 @@
     "errorMessage": "Your reflection has not been saved yet!",
     "errorTitle": "Error"
   },
+  "entryTemplates": {
+    "picker": {
+      "heading": "Want a little guidance?",
+      "subheading": "Pick a topic to get gentle prompts, or write freely."
+    },
+    "freeform": {
+      "label": "Freeform",
+      "description": "No prompts — just write what's on your mind."
+    },
+    "guidingPromptsHeading": "Gentle prompts to consider",
+    "templates": {
+      "difficult_conversation": {
+        "label": "Difficult conversation",
+        "description": "Untangle a conversation that's weighing on you.",
+        "questions": [
+          "What happened, in your own words?",
+          "What did you feel during and after the conversation?",
+          "What do you wish you had said or done differently?",
+          "What's one small step you could take from here?"
+        ]
+      },
+      "energy_drain": {
+        "label": "Energy drain",
+        "description": "Notice what's pulling your energy down.",
+        "questions": [
+          "What drained your energy today?",
+          "Where in your body or mood did you notice it?",
+          "What need of yours wasn't being met?",
+          "What's one thing that could help you recharge?"
+        ]
+      },
+      "gratitude_win": {
+        "label": "Gratitude / a win",
+        "description": "Savor something good, big or small.",
+        "questions": [
+          "What went well today, even something small?",
+          "Who or what are you grateful for right now?",
+          "What did you do that you're proud of?",
+          "How can you carry this feeling forward?"
+        ]
+      }
+    }
+  },
   "entriesPage": {
     "title": "Journal",
     "subtitle": "Every entry is a step toward understanding yourself.",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -231,6 +231,49 @@
     "errorMessage": "Bài viết của bạn chưa được lưu!",
     "errorTitle": "Lỗi"
   },
+  "entryTemplates": {
+    "picker": {
+      "heading": "Bạn muốn có gợi ý không?",
+      "subheading": "Chọn một chủ đề để có gợi ý nhẹ nhàng, hoặc viết tự do."
+    },
+    "freeform": {
+      "label": "Tự do",
+      "description": "Không gợi ý — chỉ viết những gì bạn đang nghĩ."
+    },
+    "guidingPromptsHeading": "Gợi ý nhẹ nhàng để suy ngẫm",
+    "templates": {
+      "difficult_conversation": {
+        "label": "Cuộc trò chuyện khó",
+        "description": "Gỡ rối một cuộc trò chuyện đang khiến bạn trăn trở.",
+        "questions": [
+          "Điều gì đã xảy ra, theo lời của bạn?",
+          "Bạn cảm thấy thế nào trong và sau cuộc trò chuyện?",
+          "Bạn ước mình đã nói hoặc làm khác đi điều gì?",
+          "Một bước nhỏ nào bạn có thể thực hiện từ đây?"
+        ]
+      },
+      "energy_drain": {
+        "label": "Cạn năng lượng",
+        "description": "Nhận diện điều đang khiến năng lượng của bạn suy giảm.",
+        "questions": [
+          "Điều gì đã khiến bạn cạn năng lượng hôm nay?",
+          "Bạn nhận thấy điều đó ở đâu trong cơ thể hoặc tâm trạng?",
+          "Nhu cầu nào của bạn chưa được đáp ứng?",
+          "Một điều gì đó có thể giúp bạn hồi phục năng lượng?"
+        ]
+      },
+      "gratitude_win": {
+        "label": "Biết ơn / Thành công",
+        "description": "Tận hưởng một điều tốt đẹp, dù lớn hay nhỏ.",
+        "questions": [
+          "Điều gì đã diễn ra tốt đẹp hôm nay, dù là điều nhỏ nhặt?",
+          "Bạn đang biết ơn ai hoặc điều gì ngay lúc này?",
+          "Bạn đã làm điều gì khiến bạn tự hào?",
+          "Làm sao để bạn giữ cảm giác này tiếp diễn?"
+        ]
+      }
+    }
+  },
   "entriesPage": {
     "title": "Nhật ký tự chiêm nghiệm",
     "subtitle": "Mỗi dòng nhật ký là một bước để làm rõ chính mình.",

--- a/src/models/__tests__/entryTemplate.test.ts
+++ b/src/models/__tests__/entryTemplate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { ENTRY_TEMPLATES, EntryTemplateKey, getEntryTemplate } from '../entryTemplate';
+
+describe('entryTemplate model', () => {
+  it('should define exactly the 3 default templates', () => {
+    expect(ENTRY_TEMPLATES).toHaveLength(3);
+    expect(ENTRY_TEMPLATES.map(t => t.key)).toEqual([
+      EntryTemplateKey.DIFFICULT_CONVERSATION,
+      EntryTemplateKey.ENERGY_DRAIN,
+      EntryTemplateKey.GRATITUDE_WIN,
+    ]);
+  });
+
+  it('should give every template a label key, description key and 3-5 guiding question keys', () => {
+    ENTRY_TEMPLATES.forEach((template) => {
+      expect(template.labelKey).toMatch(/^entryTemplates\.templates\..+\.label$/);
+      expect(template.descriptionKey).toMatch(/^entryTemplates\.templates\..+\.description$/);
+      expect(template.questionKeys.length).toBeGreaterThanOrEqual(3);
+      expect(template.questionKeys.length).toBeLessThanOrEqual(5);
+      template.questionKeys.forEach((key) => {
+        expect(key).toMatch(/^entryTemplates\.templates\..+\.questions\.\d+$/);
+      });
+    });
+  });
+
+  describe('getEntryTemplate', () => {
+    it('should return the matching template for a known key', () => {
+      const template = getEntryTemplate(EntryTemplateKey.GRATITUDE_WIN);
+      expect(template?.key).toBe(EntryTemplateKey.GRATITUDE_WIN);
+    });
+
+    it('should return undefined for an unknown key', () => {
+      expect(getEntryTemplate('not_a_real_template')).toBeUndefined();
+    });
+
+    it('should return undefined when no key is provided', () => {
+      expect(getEntryTemplate(undefined)).toBeUndefined();
+      expect(getEntryTemplate(null)).toBeUndefined();
+    });
+  });
+});

--- a/src/models/entry.ts
+++ b/src/models/entry.ts
@@ -6,6 +6,7 @@ export interface Entry {
   title: string;
   reflection: string;
   emotions: string[];
+  templateKey?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -14,6 +15,7 @@ export interface CreateEntryRequest {
   title: string;
   reflection: string;
   emotions: Emotion[];
+  templateKey?: string;
 }
 
 export interface UpdateEntryRequest {
@@ -21,4 +23,5 @@ export interface UpdateEntryRequest {
   title?: string;
   reflection?: string;
   emotions?: Emotion[];
+  templateKey?: string;
 }

--- a/src/models/entryTemplate.ts
+++ b/src/models/entryTemplate.ts
@@ -1,0 +1,59 @@
+export const EntryTemplateKey = {
+  DIFFICULT_CONVERSATION: 'difficult_conversation',
+  ENERGY_DRAIN: 'energy_drain',
+  GRATITUDE_WIN: 'gratitude_win'
+} as const;
+
+export type EntryTemplateKey = typeof EntryTemplateKey[keyof typeof EntryTemplateKey];
+
+export interface EntryTemplate {
+  key: EntryTemplateKey;
+  icon: string;
+  labelKey: string;
+  descriptionKey: string;
+  questionKeys: string[];
+}
+
+export const ENTRY_TEMPLATES: EntryTemplate[] = [
+  {
+    key: EntryTemplateKey.DIFFICULT_CONVERSATION,
+    icon: '💬',
+    labelKey: 'entryTemplates.templates.difficult_conversation.label',
+    descriptionKey: 'entryTemplates.templates.difficult_conversation.description',
+    questionKeys: [
+      'entryTemplates.templates.difficult_conversation.questions.0',
+      'entryTemplates.templates.difficult_conversation.questions.1',
+      'entryTemplates.templates.difficult_conversation.questions.2',
+      'entryTemplates.templates.difficult_conversation.questions.3'
+    ]
+  },
+  {
+    key: EntryTemplateKey.ENERGY_DRAIN,
+    icon: '🔋',
+    labelKey: 'entryTemplates.templates.energy_drain.label',
+    descriptionKey: 'entryTemplates.templates.energy_drain.description',
+    questionKeys: [
+      'entryTemplates.templates.energy_drain.questions.0',
+      'entryTemplates.templates.energy_drain.questions.1',
+      'entryTemplates.templates.energy_drain.questions.2',
+      'entryTemplates.templates.energy_drain.questions.3'
+    ]
+  },
+  {
+    key: EntryTemplateKey.GRATITUDE_WIN,
+    icon: '🌟',
+    labelKey: 'entryTemplates.templates.gratitude_win.label',
+    descriptionKey: 'entryTemplates.templates.gratitude_win.description',
+    questionKeys: [
+      'entryTemplates.templates.gratitude_win.questions.0',
+      'entryTemplates.templates.gratitude_win.questions.1',
+      'entryTemplates.templates.gratitude_win.questions.2',
+      'entryTemplates.templates.gratitude_win.questions.3'
+    ]
+  }
+];
+
+export const getEntryTemplate = (key?: string | null): EntryTemplate | undefined => {
+  if (!key) return undefined;
+  return ENTRY_TEMPLATES.find(template => template.key === key);
+};

--- a/src/pages/EntriesPage/EditEntryPage/EditEntryPage.tsx
+++ b/src/pages/EntriesPage/EditEntryPage/EditEntryPage.tsx
@@ -6,6 +6,7 @@ import { CircularProgress } from '@mui/material';
 import EmotionCapture from '../components/EmotionCapture/EmotionCapture';
 import ReflectionCapture from '../components/ReflectionCapture/ReflectionCapture';
 import { Emotion } from '../../../models/emotion';
+import { getEntryTemplate } from '../../../models/entryTemplate';
 import { entriesService } from '../../../services/entriesService';
 import { useUpdateEntryMutation } from '../../../queries/entriesQueryHook';
 import { APP_ROUTES } from '../../../constants/route';
@@ -27,6 +28,9 @@ const EditEntryPage: React.FC = () => {
   const [reflectionTitle, setReflectionTitle] = useState('');
   const [reflectionText, setReflectionText] = useState('');
   const reflectionRef = useRef<HTMLDivElement>(null);
+
+  const selectedTemplate = getEntryTemplate(entry?.templateKey);
+  const guidingPrompts = selectedTemplate?.questionKeys.map((key) => t(key));
 
   useEffect(() => {
     if (!id) return;
@@ -70,6 +74,7 @@ const EditEntryPage: React.FC = () => {
         title: reflectionTitle.trim(),
         reflection: reflectionText.trim(),
         emotions: selectedEmotions,
+        ...(entry?.templateKey ? { templateKey: entry.templateKey } : {}),
       },
       {
         onSuccess: () => {
@@ -136,6 +141,7 @@ const EditEntryPage: React.FC = () => {
                 onFormChange={handleFormChange}
                 initialTitle={entry.title}
                 initialReflection={entry.reflection || ''}
+                guidingPrompts={guidingPrompts}
               />
             </div>
           )}

--- a/src/pages/EntriesPage/NewEntryPage/NewEntryPage.tsx
+++ b/src/pages/EntriesPage/NewEntryPage/NewEntryPage.tsx
@@ -5,8 +5,10 @@ import { LuLock, LuCheck } from 'react-icons/lu';
 import './NewEntryPage.scss';
 import EmotionCapture from '../components/EmotionCapture/EmotionCapture';
 import ReflectionCapture from '../components/ReflectionCapture/ReflectionCapture';
+import TemplatePicker from '../../../components/TemplatePicker/TemplatePicker';
 import { Emotion } from '../../../models/emotion';
 import type { CreateEntryRequest } from '../../../models/entry';
+import { getEntryTemplate } from '../../../models/entryTemplate';
 import { entriesService } from '../../../services/entriesService';
 import { APP_ROUTES } from '../../../constants/route';
 import { useSnackbar } from '../../../providers/SnackbarProvider';
@@ -17,10 +19,14 @@ const NewEntryPage: React.FC = () => {
   const { t } = useTranslation();
   const { showSnackbar } = useSnackbar();
   const [selectedEmotions, setSelectedEmotions] = useState<Emotion[]>([]);
+  const [selectedTemplateKey, setSelectedTemplateKey] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [reflectionTitle, setReflectionTitle] = useState('');
   const [reflectionText, setReflectionText] = useState('');
   const reflectionRef = useRef<HTMLDivElement>(null);
+
+  const selectedTemplate = getEntryTemplate(selectedTemplateKey);
+  const guidingPrompts = selectedTemplate?.questionKeys.map((key) => t(key));
 
   const handleEmotionToggle = (emotion: Emotion) => {
     setSelectedEmotions(prev => {
@@ -50,6 +56,7 @@ const NewEntryPage: React.FC = () => {
         title: reflectionTitle.trim(),
         reflection: reflectionText.trim(),
         emotions: selectedEmotions,
+        ...(selectedTemplateKey ? { templateKey: selectedTemplateKey } : {}),
       };
 
       await entriesService.createEntry(entry);
@@ -92,6 +99,14 @@ const NewEntryPage: React.FC = () => {
       {/* Content */}
       <div className="safe-space__content">
         <div className="safe-space__card">
+          {/* Template Section */}
+          <TemplatePicker
+            selectedTemplateKey={selectedTemplateKey}
+            onSelect={setSelectedTemplateKey}
+          />
+
+          <div className="safe-space__divider" />
+
           {/* Emotion Section */}
           <EmotionCapture
             selectedEmotions={selectedEmotions}
@@ -106,6 +121,7 @@ const NewEntryPage: React.FC = () => {
               <ReflectionCapture
                 selectedEmotions={selectedEmotions}
                 onFormChange={handleFormChange}
+                guidingPrompts={guidingPrompts}
               />
             </div>
           )}

--- a/src/pages/EntriesPage/components/ReflectionCapture/ReflectionCapture.scss
+++ b/src/pages/EntriesPage/components/ReflectionCapture/ReflectionCapture.scss
@@ -40,6 +40,36 @@
       }
     }
 
+    .guiding-prompts {
+      padding: var(--spacing-md);
+      background: color-mix(in srgb, var(--c-secondary), transparent 92%);
+      border: 1px solid color-mix(in srgb, var(--c-secondary), transparent 70%);
+      border-radius: var(--border-radius-md);
+
+      &__heading {
+        margin: 0 0 var(--spacing-xs) 0;
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-bold);
+        color: var(--c-text-on-dark);
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+
+      &__list {
+        margin: 0;
+        padding-left: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      &__item {
+        font-size: var(--font-size-sm);
+        color: var(--c-text-muted-on-dark);
+        line-height: var(--line-height-relaxed);
+      }
+    }
+
     .reflection-form {
       display: flex;
       flex-direction: column;

--- a/src/pages/EntriesPage/components/ReflectionCapture/ReflectionCapture.tsx
+++ b/src/pages/EntriesPage/components/ReflectionCapture/ReflectionCapture.tsx
@@ -8,13 +8,15 @@ interface ReflectionCaptureProps {
   onFormChange?: (title: string, reflection: string) => void;
   initialTitle?: string;
   initialReflection?: string;
+  guidingPrompts?: string[];
 }
 
 const ReflectionCapture: React.FC<ReflectionCaptureProps> = ({
   selectedEmotions,
   onFormChange,
   initialTitle = '',
-  initialReflection = ''
+  initialReflection = '',
+  guidingPrompts
 }) => {
   const { t } = useTranslation();
   const [title, setTitle] = useState(initialTitle);
@@ -47,6 +49,17 @@ const ReflectionCapture: React.FC<ReflectionCaptureProps> = ({
             ))}
           </div>
         </div>
+
+        {guidingPrompts && guidingPrompts.length > 0 && (
+          <div className="guiding-prompts">
+            <p className="guiding-prompts__heading">{t('entryTemplates.guidingPromptsHeading')}</p>
+            <ul className="guiding-prompts__list">
+              {guidingPrompts.map((prompt, index) => (
+                <li key={index} className="guiding-prompts__item">{prompt}</li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         <div className="reflection-form">
           <div className="input-group">


### PR DESCRIPTION
## Summary
- Adds a template picker to `/entries/new` (and shows guiding prompts on `/entries/edit/:id`) with 3 scaffolded default templates: Difficult conversation, Energy drain, Gratitude/win — freeform remains the default (no template).
- Guiding questions render above the reflection textarea when a template is picked; freeform behavior is unchanged.
- Persists which template was used via the existing optional `templateKey` on `Entry`/`CreateEntryRequest`/`UpdateEntryRequest` (BE already round-trips this field).
- New: `src/models/entryTemplate.ts`, `src/components/TemplatePicker/`.
- Edited: `NewEntryPage.tsx`, `EditEntryPage.tsx`, `ReflectionCapture.tsx` (opt-in `guidingPrompts?` prop), `models/entry.ts`.
- i18n: new `entryTemplates` namespace, inserted after `newEntryPage` in en.json/vi.json (pure insertion, EN+VI parity verified).

## Test plan
- [x] `npx tsc --noEmit` — only the 4 pre-existing baseline errors (unrelated files)
- [x] `npx vitest run` (new tests) — 10/10 passing
- [x] i18n dup-key + `entryTemplates` namespace parity check — OK
- [x] No new dependencies, `MobileFooter.tsx`/route.ts/AppRoutes.tsx untouched (feature lives inline in the existing entry flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)