### PR TITLE
feat: Dashboard (energy trend + breakdowns)

### DIFF
--- a/src/components/charts/EnergyTrendChart.scss
+++ b/src/components/charts/EnergyTrendChart.scss
@@ -1,0 +1,46 @@
+@use '../../styles/_variables' as *;
+
+.energy-trend-chart {
+  width: 100%;
+
+  &--empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 160px;
+    color: var(--garden-text-muted);
+    font-size: var(--font-size-sm);
+    text-align: center;
+    padding: var(--spacing-lg);
+  }
+
+  &__svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  &__gridline {
+    stroke: rgba(166, 123, 91, 0.15);
+    stroke-width: 1;
+  }
+
+  &__line {
+    stroke: var(--garden-grass);
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  &__dot {
+    fill: var(--garden-grass);
+    stroke: var(--c-surface);
+    stroke-width: 1.5;
+  }
+
+  &__tick {
+    fill: var(--garden-text-muted);
+    font-size: 9px;
+    font-family: var(--font-family-primary);
+  }
+}

--- a/src/components/charts/EnergyTrendChart.tsx
+++ b/src/components/charts/EnergyTrendChart.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { motion } from 'framer-motion';
+import type { EnergyTrendPoint } from '../../utils/energyStatsUtil';
+import './EnergyTrendChart.scss';
+
+export interface EnergyTrendChartProps {
+  data: EnergyTrendPoint[];
+  emptyLabel: string;
+}
+
+const WIDTH = 600;
+const HEIGHT = 240;
+const PADDING_X = 32;
+const PADDING_Y = 24;
+const MIN_LEVEL = 0;
+const MAX_LEVEL = 10;
+const GRID_LEVELS = [0, 2.5, 5, 7.5, 10];
+
+/**
+ * Dependency-free inline SVG line/area chart of daily average energy
+ * level over time. Responsive via viewBox, themed via CSS variables.
+ */
+const EnergyTrendChart = ({ data, emptyLabel }: EnergyTrendChartProps) => {
+  const { i18n } = useTranslation();
+
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(i18n.language, { month: 'short', day: 'numeric' }),
+    [i18n.language]
+  );
+
+  const points = useMemo(() => {
+    if (!data.length) return [];
+
+    const innerWidth = WIDTH - PADDING_X * 2;
+    const innerHeight = HEIGHT - PADDING_Y * 2;
+    const stepX = data.length > 1 ? innerWidth / (data.length - 1) : 0;
+
+    return data.map((point, index) => {
+      const x = data.length > 1 ? PADDING_X + stepX * index : WIDTH / 2;
+      const ratio = (point.avgLevel - MIN_LEVEL) / (MAX_LEVEL - MIN_LEVEL);
+      const clampedRatio = Math.min(Math.max(ratio, 0), 1);
+      const y = PADDING_Y + innerHeight * (1 - clampedRatio);
+      return { ...point, x, y };
+    });
+  }, [data]);
+
+  if (!points.length) {
+    return <div className="energy-trend-chart energy-trend-chart--empty">{emptyLabel}</div>;
+  }
+
+  const linePath = points.map((p, index) => `${index === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+  const areaPath = `${linePath} L ${points[points.length - 1].x} ${HEIGHT - PADDING_Y} L ${points[0].x} ${HEIGHT - PADDING_Y} Z`;
+
+  const tickEvery = Math.max(1, Math.ceil(points.length / 6));
+
+  return (
+    <div className="energy-trend-chart">
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="energy-trend-chart__svg"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+      >
+        <defs>
+          <linearGradient id="energyTrendFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--garden-grass)" stopOpacity="0.35" />
+            <stop offset="100%" stopColor="var(--garden-grass)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {GRID_LEVELS.map((level) => {
+          const y = PADDING_Y + (HEIGHT - PADDING_Y * 2) * (1 - level / MAX_LEVEL);
+          return (
+            <line
+              key={level}
+              x1={PADDING_X}
+              y1={y}
+              x2={WIDTH - PADDING_X}
+              y2={y}
+              className="energy-trend-chart__gridline"
+            />
+          );
+        })}
+
+        <motion.path
+          d={areaPath}
+          fill="url(#energyTrendFill)"
+          stroke="none"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6 }}
+        />
+
+        <motion.path
+          d={linePath}
+          fill="none"
+          className="energy-trend-chart__line"
+          initial={{ pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ duration: 0.8, ease: 'easeOut' }}
+        />
+
+        {points.map((p) => (
+          <circle key={p.date} cx={p.x} cy={p.y} r={3} className="energy-trend-chart__dot">
+            <title>{`${p.date}: ${p.avgLevel}`}</title>
+          </circle>
+        ))}
+
+        {points.map((p, index) =>
+          index % tickEvery === 0 || index === points.length - 1 ? (
+            <text
+              key={`label-${p.date}`}
+              x={p.x}
+              y={HEIGHT - 4}
+              className="energy-trend-chart__tick"
+              textAnchor="middle"
+            >
+              {dateFormatter.format(new Date(`${p.date}T00:00:00`))}
+            </text>
+          ) : null
+        )}
+      </svg>
+    </div>
+  );
+};
+
+export default EnergyTrendChart;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -79,7 +79,8 @@
     }
   },
   "nav": {
-    "energy": "Energy"
+    "energy": "Energy",
+    "dashboard": "Dashboard"
   },
   "energyLog": {
     "quickLogTitle": "How's your energy right now?",
@@ -105,6 +106,34 @@
       "message": "Are you sure you want to delete this energy log?",
       "confirm": "Delete",
       "cancel": "Cancel"
+    }
+  },
+  "dashboard": {
+    "title": "Energy Dashboard",
+    "subtitle": "See how your energy shifts over time and where it goes.",
+    "loginRequired": "Please log in to view your energy dashboard.",
+    "rangeLabel": "Last {{days}} days",
+    "logButton": "Log Energy",
+    "empty": "No energy logs yet. Log your energy to see your dashboard come to life.",
+    "trend": {
+      "title": "Energy Trend",
+      "subtitle": "Average energy level per day",
+      "empty": "No energy logs yet for this period. Start logging to see your trend."
+    },
+    "byContext": {
+      "title": "Energy by Context",
+      "subtitle": "Average energy level for each activity",
+      "empty": "Log some energy entries with context tags to see this breakdown."
+    },
+    "byCount": {
+      "title": "Logs by Context",
+      "subtitle": "How many times you've logged energy in each context",
+      "empty": "No logs yet."
+    },
+    "summary": {
+      "average": "Average level",
+      "totalLogs": "Total logs",
+      "bestContext": "Highest energy context"
     }
   },
   "profilePage": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -13,6 +13,7 @@
     "reflection": "Tự chiêm nghiệm",
     "emotion": "Cảm xúc",
     "energy": "Năng lượng",
+    "dashboard": "Bảng thông tin",
     "method": "Phương pháp",
     "journal": "Nhật ký",
     "profile": "Tôi",
@@ -187,6 +188,34 @@
       "message": "Bạn có chắc muốn xóa bản ghi năng lượng này?",
       "confirm": "Xóa",
       "cancel": "Hủy"
+    }
+  },
+  "dashboard": {
+    "title": "Bảng thông tin Năng lượng",
+    "subtitle": "Xem năng lượng của bạn thay đổi theo thời gian và ở đâu.",
+    "loginRequired": "Vui lòng đăng nhập để xem bảng thông tin năng lượng.",
+    "rangeLabel": "{{days}} ngày gần nhất",
+    "logButton": "Ghi năng lượng",
+    "empty": "Chưa có bản ghi năng lượng nào. Hãy ghi năng lượng để xem bảng thông tin của bạn.",
+    "trend": {
+      "title": "Xu hướng năng lượng",
+      "subtitle": "Mức năng lượng trung bình mỗi ngày",
+      "empty": "Chưa có bản ghi năng lượng trong khoảng thời gian này. Hãy bắt đầu ghi để xem xu hướng."
+    },
+    "byContext": {
+      "title": "Năng lượng theo hoạt động",
+      "subtitle": "Mức năng lượng trung bình cho mỗi hoạt động",
+      "empty": "Hãy ghi năng lượng kèm hoạt động để xem biểu đồ này."
+    },
+    "byCount": {
+      "title": "Số lần ghi theo hoạt động",
+      "subtitle": "Số lần bạn đã ghi năng lượng cho mỗi hoạt động",
+      "empty": "Chưa có bản ghi nào."
+    },
+    "summary": {
+      "average": "Mức trung bình",
+      "totalLogs": "Tổng số bản ghi",
+      "bestContext": "Hoạt động năng lượng cao nhất"
     }
   },
   "profilePage": {

--- a/src/layouts/MimoHeader/MimoHeader.tsx
+++ b/src/layouts/MimoHeader/MimoHeader.tsx
@@ -93,6 +93,13 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
             {t('nav.energy')}
           </a>
           <a
+            onClick={() => navigate(APP_ROUTES.STATISTICS)}
+            className={isActive(APP_ROUTES.STATISTICS) ? 'active' : ''}
+            style={{ cursor: 'pointer' }}
+          >
+            {t('nav.dashboard')}
+          </a>
+          <a
             onClick={() => navigate(APP_ROUTES.PHUONG_PHAP)}
             className={isActive(APP_ROUTES.PHUONG_PHAP) ? 'active' : ''}
             style={{ cursor: 'pointer' }}
@@ -164,6 +171,7 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
           <a onClick={() => navTo(APP_ROUTES.REFLECTION_ZONE)} style={{ cursor: 'pointer' }}>{t('nav.reflection')}</a>
           <a onClick={() => navTo(APP_ROUTES.EMOTION_ZONE)} style={{ cursor: 'pointer' }}>{t('nav.emotion')}</a>
           <a onClick={() => navTo(APP_ROUTES.ENERGY_HISTORY)} style={{ cursor: 'pointer' }}>{t('nav.energy')}</a>
+          <a onClick={() => navTo(APP_ROUTES.STATISTICS)} style={{ cursor: 'pointer' }}>{t('nav.dashboard')}</a>
           <a onClick={() => navTo(APP_ROUTES.PHUONG_PHAP)} style={{ cursor: 'pointer' }}>{t('nav.method')}</a>
           <div className="divider" />
           <div className="mobile-language-switcher">

--- a/src/pages/StatisticsPage/StatisticsPage.scss
+++ b/src/pages/StatisticsPage/StatisticsPage.scss
@@ -1,12 +1,175 @@
-// Import responsive system
 @use '../../styles/_variables' as *;
 @use '../../styles/_responsive' as *;
 
 .statistics-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: calc(var(--header-height-mobile) + var(--spacing-lg)) var(--spacing-md) var(--spacing-3xl);
   background: var(--c-background);
-  width: 100%;
-  height: 100%;
+  min-height: 100%;
+
+  &__hero {
+    text-align: center;
+    margin-bottom: var(--spacing-2xl);
+  }
+
+  &__icon {
+    width: 72px;
+    height: 72px;
+    margin: 0 auto var(--spacing-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--garden-parchment);
+    border: 2px solid rgba(91, 140, 90, 0.35);
+    border-radius: 50%;
+    color: var(--garden-grass);
+  }
+
+  h1 {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-2xl);
+    color: var(--garden-text);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  p {
+    color: var(--garden-text-muted);
+    font-size: var(--font-size-lg);
+  }
+
+  &__log-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: var(--spacing-md);
+    padding: 12px 24px;
+    background: var(--garden-grass);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: var(--font-weight-semibold);
+
+    &:hover {
+      background: var(--c-primary-hover);
+    }
+  }
+
+  &__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-xl);
+  }
+
+  &__content {
+    background: var(--garden-parchment);
+    border-radius: var(--border-radius-lg);
+    padding: var(--spacing-xl);
+    border: 1px solid rgba(166, 123, 91, 0.25);
+    margin-bottom: var(--spacing-xl);
+  }
+
+  &__section-title {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-xl);
+    color: var(--garden-text);
+    margin: 0 0 var(--spacing-xs);
+  }
+
+  &__section-subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--garden-text-muted);
+    margin: 0 0 var(--spacing-lg);
+  }
+
+  &__loading,
+  &__empty,
+  &__empty-state {
+    text-align: center;
+    padding: var(--spacing-2xl);
+    color: var(--garden-text-muted);
+  }
+
+  &__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: none;
+    border: none;
+    color: var(--garden-earth);
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      color: var(--garden-grass);
+    }
+  }
+
+  // Copied from EmotionZonePage's .emotion-chart bar pattern (not extracted
+  // to a shared module, per the isolated-worktree rule for this feature).
+  .emotion-chart {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+
+    &__row {
+      display: grid;
+      grid-template-columns: 28px 90px 1fr 40px;
+      align-items: center;
+      gap: var(--spacing-sm);
+    }
+
+    &__icon {
+      font-size: 1.2rem;
+    }
+
+    &__label {
+      font-size: var(--font-size-sm);
+      color: var(--garden-text);
+    }
+
+    &__bar-track {
+      height: 8px;
+      background: rgba(255, 255, 255, 0.6);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    &__bar-fill {
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.5s ease;
+    }
+
+    &__count {
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-semibold);
+      color: var(--garden-text-muted);
+      text-align: right;
+    }
+  }
+}
+
+.statistics-summary-card {
+  background: var(--c-surface);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-md);
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  text-align: center;
+
+  &__label {
+    font-size: var(--font-size-xs);
+    color: var(--garden-text-muted);
+  }
+
+  &__value {
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
+    color: var(--garden-text);
+  }
 }

--- a/src/pages/StatisticsPage/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage/StatisticsPage.tsx
@@ -1,13 +1,183 @@
-import React from 'react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { CircularProgress } from '@mui/material';
+import { LuArrowLeft, LuChartLine, LuPlus } from 'react-icons/lu';
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import QuickEnergyLog from '../../components/QuickEnergyLog/QuickEnergyLog';
+import EnergyTrendChart from '../../components/charts/EnergyTrendChart';
+import { APP_ROUTES } from '../../constants/route';
+import { useAuth } from '../../providers/AuthProvider';
+import { useEnergyStatsQuery } from '../../queries/energyStatsQueryHook';
+import {
+  getAverageEnergyLevel,
+  getBestContextTag,
+  getContextTagDistribution,
+  getEnergyTrend,
+} from '../../utils/energyStatsUtil';
 import './StatisticsPage.scss';
 
+const RANGE_DAYS = 30;
 
-const StatisticsPage: React.FC = () => {
+const StatisticsPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+
+  const [logDialogOpen, setLogDialogOpen] = useState(false);
+
+  const { data, isLoading } = useEnergyStatsQuery(RANGE_DAYS);
+  const logs = useMemo(() => data || [], [data]);
+
+  const trend = useMemo(() => getEnergyTrend(logs), [logs]);
+  const contextDist = useMemo(() => getContextTagDistribution(logs), [logs]);
+  const averageLevel = useMemo(() => getAverageEnergyLevel(logs), [logs]);
+  const bestContext = useMemo(() => getBestContextTag(contextDist), [contextDist]);
+
+  const maxAvgLevel = useMemo(
+    () => Math.max(...contextDist.map((item) => item.avgLevel), 1),
+    [contextDist]
+  );
+  const maxCount = useMemo(
+    () => Math.max(...contextDist.map((item) => item.count), 1),
+    [contextDist]
+  );
+
+  if (!isAuthenticated) {
     return (
-        <div className="statistics-page">
-            <h1>Statistics</h1>
+      <div className="statistics-page">
+        <div className="statistics-page__empty">
+          <p>{t('dashboard.loginRequired')}</p>
+          <button type="button" onClick={() => navigate(APP_ROUTES.LOGIN)}>
+            {t('nav.login')}
+          </button>
         </div>
+      </div>
     );
+  }
+
+  const hasLogs = logs.length > 0;
+
+  return (
+    <div className="statistics-page">
+      <Breadcrumb
+        items={[
+          { label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME },
+          { label: t('dashboard.title') },
+        ]}
+      />
+
+      <section className="statistics-page__hero">
+        <div className="statistics-page__icon">
+          <LuChartLine size={28} />
+        </div>
+        <h1>{t('dashboard.title')}</h1>
+        <p>{t('dashboard.subtitle')}</p>
+        <button type="button" className="statistics-page__log-btn" onClick={() => setLogDialogOpen(true)}>
+          <LuPlus size={18} />
+          <span>{t('dashboard.logButton')}</span>
+        </button>
+      </section>
+
+      {isLoading ? (
+        <div className="statistics-page__loading">
+          <CircularProgress size={28} />
+        </div>
+      ) : !hasLogs ? (
+        <div className="statistics-page__content">
+          <div className="statistics-page__empty-state">
+            <p>{t('dashboard.empty')}</p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <section className="statistics-page__summary">
+            <div className="statistics-summary-card">
+              <span className="statistics-summary-card__label">{t('dashboard.summary.average')}</span>
+              <span className="statistics-summary-card__value">{averageLevel}</span>
+            </div>
+            <div className="statistics-summary-card">
+              <span className="statistics-summary-card__label">{t('dashboard.summary.totalLogs')}</span>
+              <span className="statistics-summary-card__value">{logs.length}</span>
+            </div>
+            {bestContext && (
+              <div className="statistics-summary-card">
+                <span className="statistics-summary-card__label">{t('dashboard.summary.bestContext')}</span>
+                <span className="statistics-summary-card__value">
+                  {bestContext.icon} {bestContext.label}
+                </span>
+              </div>
+            )}
+          </section>
+
+          <section className="statistics-page__content">
+            <h2 className="statistics-page__section-title">{t('dashboard.trend.title')}</h2>
+            <p className="statistics-page__section-subtitle">{t('dashboard.trend.subtitle')}</p>
+            <EnergyTrendChart data={trend} emptyLabel={t('dashboard.trend.empty')} />
+          </section>
+
+          <section className="statistics-page__content">
+            <h2 className="statistics-page__section-title">{t('dashboard.byContext.title')}</h2>
+            <p className="statistics-page__section-subtitle">{t('dashboard.byContext.subtitle')}</p>
+            <div className="emotion-chart">
+              {contextDist.map((item) => (
+                <div
+                  key={item.contextTag}
+                  className={`emotion-chart__row ${item.count === 0 ? 'emotion-chart__row--empty' : ''}`}
+                >
+                  <span className="emotion-chart__icon">{item.icon}</span>
+                  <span className="emotion-chart__label">{item.label}</span>
+                  <div className="emotion-chart__bar-track">
+                    <div
+                      className="emotion-chart__bar-fill"
+                      style={{
+                        width: `${(item.avgLevel / maxAvgLevel) * 100}%`,
+                        backgroundColor: 'var(--garden-grass)',
+                      }}
+                    />
+                  </div>
+                  <span className="emotion-chart__count">{item.avgLevel}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="statistics-page__content">
+            <h2 className="statistics-page__section-title">{t('dashboard.byCount.title')}</h2>
+            <p className="statistics-page__section-subtitle">{t('dashboard.byCount.subtitle')}</p>
+            <div className="emotion-chart">
+              {contextDist.map((item) => (
+                <div
+                  key={item.contextTag}
+                  className={`emotion-chart__row ${item.count === 0 ? 'emotion-chart__row--empty' : ''}`}
+                >
+                  <span className="emotion-chart__icon">{item.icon}</span>
+                  <span className="emotion-chart__label">{item.label}</span>
+                  <div className="emotion-chart__bar-track">
+                    <div
+                      className="emotion-chart__bar-fill"
+                      style={{
+                        width: `${(item.count / maxCount) * 100}%`,
+                        backgroundColor: 'var(--garden-bloom)',
+                      }}
+                    />
+                  </div>
+                  <span className="emotion-chart__count">{item.count}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+
+      <button type="button" className="statistics-page__back" onClick={() => navigate(APP_ROUTES.WELCOME)}>
+        <LuArrowLeft size={18} />
+        <span>{t('zonePage.backToGarden')}</span>
+      </button>
+
+      <QuickEnergyLog open={logDialogOpen} onClose={() => setLogDialogOpen(false)} />
+    </div>
+  );
 };
 
-export default StatisticsPage;    
+export default StatisticsPage;

--- a/src/queries/energyStatsQueryHook.ts
+++ b/src/queries/energyStatsQueryHook.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import type { EnergyLog } from '../models/energyLog';
+import { energyStatsService } from '../services/energyStatsService';
+
+/**
+ * Fetches energy logs for the last `days` days, used to power the
+ * energy Dashboard (trend chart + categorical breakdowns).
+ *
+ * The query key is intentionally prefixed with 'energyLogs' so that the
+ * QuickEnergyLog create mutation's refetchQueries({ queryKey: ['energyLogs'] })
+ * automatically refreshes this data too.
+ */
+export const useEnergyStatsQuery = (days: number = 30) => {
+  return useQuery<EnergyLog[]>({
+    queryKey: ['energyLogs', 'stats', days],
+    queryFn: () => energyStatsService.getEnergyRange(days),
+    staleTime: 1000 * 60 * 5, // 5 mins cache
+  });
+};

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -5,7 +5,6 @@ import { APP_ROUTES } from '../constants/route';
 import MainLayout from '../layouts/MainLayout/MainLayout';
 import EntriesListPage from '../pages/EntriesPage/EntriesListPage/EntriesListPage';
 import QuotesPage from '../pages/QuotesPage/QuotesPage';
-import StatisticsPage from '../pages/StatisticsPage/StatisticsPage';
 import ProtectedRoute from './ProtectedRoute';
 
 const NewEntryPage = lazy(() => import('../pages/EntriesPage/NewEntryPage/NewEntryPage'));
@@ -18,6 +17,7 @@ const GardenZonePage = lazy(() => import('../pages/GardenZonePage/GardenZonePage
 const EmotionZonePage = lazy(() => import('../pages/EmotionZonePage/EmotionZonePage'));
 const SignupPage = lazy(() => import('../pages/SignupPage/SignupPage'));
 const EnergyHistoryPage = lazy(() => import('../pages/EnergyHistoryPage/EnergyHistoryPage'));
+const StatisticsPage = lazy(() => import('../pages/StatisticsPage/StatisticsPage'));
 
 export const AppRoutes = () => {
     return (

--- a/src/services/energyStatsService.ts
+++ b/src/services/energyStatsService.ts
@@ -1,0 +1,9 @@
+import type { EnergyLog } from '../models/energyLog';
+import axiosInstance from './axiosSetup';
+
+export const energyStatsService = {
+  async getEnergyRange(days: number = 30): Promise<EnergyLog[]> {
+    const { data } = await axiosInstance.get<EnergyLog[]>(`/energy-logs/range?days=${days}`);
+    return data;
+  },
+};

--- a/src/utils/__tests__/energyStatsUtil.test.ts
+++ b/src/utils/__tests__/energyStatsUtil.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEnergyTrend,
+  getContextTagDistribution,
+  getAverageEnergyLevel,
+  getBestContextTag,
+} from '../energyStatsUtil';
+import { ContextTag, CONTEXT_TAG_DATA } from '../../models/energyLog';
+import type { EnergyLog } from '../../models/energyLog';
+
+const makeLog = (overrides: Partial<EnergyLog>): EnergyLog => ({
+  id: overrides.id || Math.random().toString(36),
+  userId: 'user-1',
+  level: 5,
+  contextTag: ContextTag.WORK,
+  loggedAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+// Builds an ISO string for a specific local date/time so tests are
+// independent of the machine's timezone offset math.
+const localIso = (year: number, month: number, day: number, hour = 12): string => {
+  return new Date(year, month - 1, day, hour, 0, 0).toISOString();
+};
+
+describe('energyStatsUtil', () => {
+  describe('getEnergyTrend', () => {
+    it('returns an empty array for no logs', () => {
+      expect(getEnergyTrend([])).toEqual([]);
+    });
+
+    it('buckets logs by local calendar day and averages the level', () => {
+      const logs: EnergyLog[] = [
+        makeLog({ level: 4, loggedAt: localIso(2026, 7, 18) }),
+        makeLog({ level: 8, loggedAt: localIso(2026, 7, 18, 20) }),
+        makeLog({ level: 6, loggedAt: localIso(2026, 7, 19) }),
+      ];
+
+      const trend = getEnergyTrend(logs);
+
+      expect(trend).toEqual([
+        { date: '2026-07-18', avgLevel: 6, count: 2 },
+        { date: '2026-07-19', avgLevel: 6, count: 1 },
+      ]);
+    });
+
+    it('sorts points ascending by date regardless of input order', () => {
+      const logs: EnergyLog[] = [
+        makeLog({ level: 5, loggedAt: localIso(2026, 7, 20) }),
+        makeLog({ level: 5, loggedAt: localIso(2026, 7, 15) }),
+      ];
+
+      const trend = getEnergyTrend(logs);
+
+      expect(trend.map((p) => p.date)).toEqual(['2026-07-15', '2026-07-20']);
+    });
+
+    it('rounds average level to one decimal place', () => {
+      const logs: EnergyLog[] = [
+        makeLog({ level: 3, loggedAt: localIso(2026, 7, 18) }),
+        makeLog({ level: 4, loggedAt: localIso(2026, 7, 18) }),
+        makeLog({ level: 4, loggedAt: localIso(2026, 7, 18) }),
+      ];
+
+      const trend = getEnergyTrend(logs);
+
+      expect(trend[0].avgLevel).toBeCloseTo(3.7, 1);
+    });
+  });
+
+  describe('getContextTagDistribution', () => {
+    it('includes every known context tag even with zero logs', () => {
+      const distribution = getContextTagDistribution([]);
+      expect(distribution).toHaveLength(Object.keys(CONTEXT_TAG_DATA).length);
+      expect(distribution.every((item) => item.count === 0 && item.avgLevel === 0)).toBe(true);
+    });
+
+    it('computes count, avgLevel and percentage per tag', () => {
+      const logs: EnergyLog[] = [
+        makeLog({ level: 6, contextTag: ContextTag.WORK }),
+        makeLog({ level: 8, contextTag: ContextTag.WORK }),
+        makeLog({ level: 4, contextTag: ContextTag.REST }),
+      ];
+
+      const distribution = getContextTagDistribution(logs);
+      const work = distribution.find((item) => item.contextTag === ContextTag.WORK);
+      const rest = distribution.find((item) => item.contextTag === ContextTag.REST);
+
+      expect(work).toMatchObject({ count: 2, avgLevel: 7, percentage: 67 });
+      expect(rest).toMatchObject({ count: 1, avgLevel: 4, percentage: 33 });
+    });
+
+    it('sorts descending by count', () => {
+      const logs: EnergyLog[] = [
+        makeLog({ contextTag: ContextTag.REST }),
+        makeLog({ contextTag: ContextTag.WORK }),
+        makeLog({ contextTag: ContextTag.WORK }),
+      ];
+
+      const distribution = getContextTagDistribution(logs);
+
+      expect(distribution[0].contextTag).toBe(ContextTag.WORK);
+      expect(distribution[0].count).toBe(2);
+    });
+  });
+
+  describe('getAverageEnergyLevel', () => {
+    it('returns 0 for no logs', () => {
+      expect(getAverageEnergyLevel([])).toBe(0);
+    });
+
+    it('averages the level across all logs', () => {
+      const logs: EnergyLog[] = [makeLog({ level: 2 }), makeLog({ level: 5 }), makeLog({ level: 8 })];
+      expect(getAverageEnergyLevel(logs)).toBe(5);
+    });
+  });
+
+  describe('getBestContextTag', () => {
+    it('returns null when no tag has logs', () => {
+      const distribution = getContextTagDistribution([]);
+      expect(getBestContextTag(distribution)).toBeNull();
+    });
+
+    it('returns the tag with the highest avg level among logged tags', () => {
+      const logs: EnergyLog[] = [
+        makeLog({ level: 3, contextTag: ContextTag.WORK }),
+        makeLog({ level: 9, contextTag: ContextTag.EXERCISE }),
+      ];
+      const distribution = getContextTagDistribution(logs);
+
+      const best = getBestContextTag(distribution);
+
+      expect(best?.contextTag).toBe(ContextTag.EXERCISE);
+      expect(best?.avgLevel).toBe(9);
+    });
+  });
+});

--- a/src/utils/energyStatsUtil.ts
+++ b/src/utils/energyStatsUtil.ts
@@ -1,0 +1,107 @@
+import type { EnergyLog } from '../models/energyLog';
+import { CONTEXT_TAG_DATA, type ContextTag } from '../models/energyLog';
+
+// A single point on the energy trend chart: one local calendar day.
+export interface EnergyTrendPoint {
+  date: string; // YYYY-MM-DD (local)
+  avgLevel: number;
+  count: number;
+}
+
+// Result type for context tag distribution (avg level + log count per tag).
+export interface ContextTagDistItem {
+  contextTag: ContextTag;
+  label: string;
+  icon: string;
+  count: number;
+  avgLevel: number;
+  percentage: number;
+}
+
+/**
+ * Formats an ISO date string to a local YYYY-MM-DD bucket key.
+ * Mirrors the local-date idiom used by statsUtil.calculateDayStreak —
+ * bucketing happens in LOCAL time, not UTC.
+ */
+const formatLocalDate = (isoString: string): string => {
+  const date = new Date(isoString);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+};
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+/**
+ * Buckets energy logs by local calendar day and returns the daily
+ * average energy level, sorted ascending by date (oldest first).
+ */
+export const getEnergyTrend = (logs: EnergyLog[]): EnergyTrendPoint[] => {
+  const buckets = new Map<string, { total: number; count: number }>();
+
+  for (const log of logs) {
+    const dateStr = formatLocalDate(log.loggedAt);
+    const bucket = buckets.get(dateStr) || { total: 0, count: 0 };
+    bucket.total += log.level;
+    bucket.count += 1;
+    buckets.set(dateStr, bucket);
+  }
+
+  return Array.from(buckets.entries())
+    .map(([date, { total, count }]) => ({
+      date,
+      avgLevel: round1(total / count),
+      count,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+};
+
+/**
+ * Aggregates energy logs by context tag and returns, for every known
+ * context tag, the log count, average energy level, and share of total
+ * logs. Sorted descending by count. Mirrors statsUtil.getEmotionDistribution.
+ */
+export const getContextTagDistribution = (logs: EnergyLog[]): ContextTagDistItem[] => {
+  const total = logs.length;
+  const counts: Record<string, number> = {};
+  const totals: Record<string, number> = {};
+
+  for (const log of logs) {
+    counts[log.contextTag] = (counts[log.contextTag] || 0) + 1;
+    totals[log.contextTag] = (totals[log.contextTag] || 0) + log.level;
+  }
+
+  const distribution: ContextTagDistItem[] = Object.entries(CONTEXT_TAG_DATA).map(([key, data]) => {
+    const count = counts[key] || 0;
+    return {
+      contextTag: key as ContextTag,
+      label: data.label,
+      icon: data.icon,
+      count,
+      avgLevel: count > 0 ? round1(totals[key] / count) : 0,
+      percentage: total > 0 ? Math.round((count / total) * 100) : 0,
+    };
+  });
+
+  distribution.sort((a, b) => b.count - a.count);
+
+  return distribution;
+};
+
+/**
+ * Returns the overall average energy level across all logs, or 0 if empty.
+ */
+export const getAverageEnergyLevel = (logs: EnergyLog[]): number => {
+  if (!logs.length) return 0;
+  const sum = logs.reduce((acc, log) => acc + log.level, 0);
+  return round1(sum / logs.length);
+};
+
+/**
+ * Returns the context tag with the highest average energy level among
+ * tags that have at least one log. Returns null if no logs are tagged.
+ */
+export const getBestContextTag = (distribution: ContextTagDistItem[]): ContextTagDistItem | null => {
+  const logged = distribution.filter((item) => item.count > 0);
+  if (!logged.length) return null;
+
+  return logged.reduce((best, item) => (item.avgLevel > best.avgLevel ? item : best), logged[0]);
+};


### PR DESCRIPTION
## Summary
- Fills the `/statistics` stub with an energy Dashboard: dependency-free inline-SVG trend chart (daily avg energy, local-day bucketed) + context-tag breakdowns (avg level, log count) reusing the EmotionZonePage CSS-bar pattern + summary cards + a shortcut to `QuickEnergyLog`.
- Data: `GET /api/energy-logs/range?days=30` (BE, already merged to develop) → bucketed client-side in `energyStatsUtil.ts` (pure functions, unit tested).
- React-query key is `['energyLogs', 'stats', days]` — prefixed with `energyLogs` so logging energy elsewhere auto-refreshes the chart (matches the existing `QuickEnergyLog` mutation's `refetchQueries(['energyLogs'])`).
- `StatisticsPage` converted from eager to `lazy()` import in `AppRoutes.tsx` (was the only eagerly-imported page).
- No new dependencies — no recharts/dayjs, native `Date` + inline SVG.
- New: `src/utils/energyStatsUtil.ts`, `src/components/charts/EnergyTrendChart.tsx`, `src/services/energyStatsService.ts`, `src/queries/energyStatsQueryHook.ts`.
- i18n: new `dashboard` namespace after `energyHistoryPage`, plus `nav.dashboard`.

## Test plan
- [x] `npx tsc --noEmit` — only the 4 pre-existing baseline errors
- [x] `npx vitest run` (energyStatsUtil pure-function tests) — 11/11 passing
- [x] i18n dup-key + `dashboard` namespace parity check — OK
- [x] Confirmed query key is exactly `['energyLogs','stats',days]`
- [x] No new dependencies; `route.ts`/`MobileFooter.tsx` untouched (reuses existing `/statistics` route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)