### PR TITLE
feat: Action Protocol (create, mark-used, effectiveness)

### DIFF
--- a/src/components/MarkProtocolUsedDialog/MarkProtocolUsedDialog.scss
+++ b/src/components/MarkProtocolUsedDialog/MarkProtocolUsedDialog.scss
@@ -1,0 +1,105 @@
+@use '../../styles/_variables' as *;
+
+.mark-protocol-used-dialog {
+  &__content {
+    padding: var(--spacing-lg) !important;
+  }
+
+  &__title {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-xl);
+    color: var(--c-text-on-surface);
+    margin: 0 0 var(--spacing-xs);
+    text-align: center;
+  }
+
+  &__subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--c-text-muted);
+    text-align: center;
+    margin: 0 0 var(--spacing-md);
+  }
+
+  &__options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+  }
+
+  &__option {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius-md);
+    border: 1px solid var(--c-border);
+    background: var(--c-surface);
+    color: var(--c-text-on-surface);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    text-align: left;
+    transition: all var(--transition-fast);
+
+    &:hover {
+      border-color: var(--c-primary);
+    }
+
+    &--selected {
+      background: var(--badge-inner-bg);
+      border-color: var(--c-primary);
+      color: var(--badge-inner-text);
+      font-weight: var(--font-weight-semibold);
+    }
+  }
+
+  &__notes {
+    margin-top: var(--spacing-md);
+    width: 100%;
+    min-height: 60px;
+    resize: vertical;
+    padding: var(--spacing-sm);
+    border-radius: var(--border-radius-sm);
+    border: 1px solid var(--c-border);
+    font-family: var(--font-family-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-lg);
+  }
+
+  &__cancel,
+  &__save {
+    flex: 1;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius-md);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
+
+  &__cancel {
+    background: none;
+    border: 1px solid var(--c-border);
+    color: var(--c-text-muted);
+
+    &:hover {
+      background: var(--c-surface-subtle);
+    }
+  }
+
+  &__save {
+    background: var(--c-primary);
+    border: 1px solid var(--c-primary);
+    color: var(--c-white);
+
+    &:hover {
+      background: var(--c-primary-hover);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/src/components/MarkProtocolUsedDialog/MarkProtocolUsedDialog.tsx
+++ b/src/components/MarkProtocolUsedDialog/MarkProtocolUsedDialog.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { EffectivenessLevel } from '../../models/actionProtocol';
+import { useMarkActionProtocolUsedMutation } from '../../queries/actionProtocolQueryHook';
+import { useSnackbar } from '../../providers/SnackbarProvider';
+import './MarkProtocolUsedDialog.scss';
+
+export interface MarkProtocolUsedDialogProps {
+  open: boolean;
+  protocolId: string | null;
+  onClose: () => void;
+}
+
+const EFFECTIVENESS_OPTIONS: EffectivenessLevel[] = [
+  EffectivenessLevel.WORKED,
+  EffectivenessLevel.PARTIAL,
+  EffectivenessLevel.DIDNT_WORK
+];
+
+const MarkProtocolUsedDialog: React.FC<MarkProtocolUsedDialogProps> = ({ open, protocolId, onClose }) => {
+  const { t } = useTranslation();
+  const { showSnackbar } = useSnackbar();
+  const markUsed = useMarkActionProtocolUsedMutation();
+
+  const [effectiveness, setEffectiveness] = useState<EffectivenessLevel | null>(null);
+  const [note, setNote] = useState('');
+
+  const resetAndClose = () => {
+    setEffectiveness(null);
+    setNote('');
+    onClose();
+  };
+
+  const handleSave = () => {
+    if (!protocolId || !effectiveness || markUsed.isPending) {
+      return;
+    }
+
+    markUsed.mutate(
+      { id: protocolId, payload: { effectiveness, note: note.trim() || undefined } },
+      {
+        onSuccess: () => {
+          showSnackbar(t('actionProtocol.markUsed.savedMessage'), 'success');
+          resetAndClose();
+        },
+        onError: () => {
+          showSnackbar(t('actionProtocol.markUsed.errorMessage'), 'error');
+        },
+      }
+    );
+  };
+
+  const canSave = effectiveness !== null;
+
+  return (
+    <Dialog open={open} onClose={resetAndClose} maxWidth="xs" fullWidth className="mark-protocol-used-dialog">
+      <DialogContent className="mark-protocol-used-dialog__content">
+        <h2 className="mark-protocol-used-dialog__title">{t('actionProtocol.markUsed.title')}</h2>
+        <p className="mark-protocol-used-dialog__subtitle">{t('actionProtocol.markUsed.subtitle')}</p>
+
+        <div className="mark-protocol-used-dialog__options">
+          {EFFECTIVENESS_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={`mark-protocol-used-dialog__option ${effectiveness === option ? 'mark-protocol-used-dialog__option--selected' : ''}`}
+              onClick={() => setEffectiveness(option)}
+            >
+              {t(`actionProtocol.effectiveness.${option}`)}
+            </button>
+          ))}
+        </div>
+
+        <textarea
+          className="mark-protocol-used-dialog__notes"
+          placeholder={t('actionProtocol.markUsed.notePlaceholder')}
+          value={note}
+          maxLength={500}
+          onChange={(e) => setNote(e.target.value)}
+        />
+
+        <div className="mark-protocol-used-dialog__actions">
+          <button type="button" className="mark-protocol-used-dialog__cancel" onClick={resetAndClose}>
+            {t('actionProtocol.markUsed.cancel')}
+          </button>
+          <button
+            type="button"
+            className="mark-protocol-used-dialog__save"
+            disabled={!canSave || markUsed.isPending}
+            onClick={handleSave}
+          >
+            {markUsed.isPending ? t('actionProtocol.markUsed.saving') : t('actionProtocol.markUsed.save')}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MarkProtocolUsedDialog;

--- a/src/components/ProtocolFormDialog/ProtocolFormDialog.scss
+++ b/src/components/ProtocolFormDialog/ProtocolFormDialog.scss
@@ -1,0 +1,85 @@
+@use '../../styles/_variables' as *;
+
+.protocol-form-dialog {
+  &__content {
+    padding: var(--spacing-lg) !important;
+  }
+
+  &__title {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-xl);
+    color: var(--c-text-on-surface);
+    margin: 0 0 var(--spacing-md);
+    text-align: center;
+  }
+
+  &__label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--c-text-muted);
+    margin: var(--spacing-md) 0 var(--spacing-sm);
+  }
+
+  &__input,
+  &__textarea {
+    width: 100%;
+    padding: var(--spacing-sm);
+    border-radius: var(--border-radius-sm);
+    border: 1px solid var(--c-border);
+    font-family: var(--font-family-primary);
+    font-size: var(--font-size-sm);
+    color: var(--c-text-on-surface);
+    background: var(--c-surface);
+
+    &:focus {
+      outline: none;
+      border-color: var(--c-primary);
+    }
+  }
+
+  &__textarea {
+    min-height: 120px;
+    resize: vertical;
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-lg);
+  }
+
+  &__cancel,
+  &__save {
+    flex: 1;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius-md);
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
+
+  &__cancel {
+    background: none;
+    border: 1px solid var(--c-border);
+    color: var(--c-text-muted);
+
+    &:hover {
+      background: var(--c-surface-subtle);
+    }
+  }
+
+  &__save {
+    background: var(--c-primary);
+    border: 1px solid var(--c-primary);
+    color: var(--c-white);
+
+    &:hover {
+      background: var(--c-primary-hover);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/src/components/ProtocolFormDialog/ProtocolFormDialog.tsx
+++ b/src/components/ProtocolFormDialog/ProtocolFormDialog.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { Dialog, DialogContent } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import type { ActionProtocol } from '../../models/actionProtocol';
+import { useCreateActionProtocolMutation, useUpdateActionProtocolMutation } from '../../queries/actionProtocolQueryHook';
+import { useSnackbar } from '../../providers/SnackbarProvider';
+import './ProtocolFormDialog.scss';
+
+export interface ProtocolFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  protocol?: ActionProtocol | null;
+}
+
+const ProtocolFormDialog: React.FC<ProtocolFormDialogProps> = ({ open, onClose, protocol }) => {
+  const { t } = useTranslation();
+  const { showSnackbar } = useSnackbar();
+  const createProtocol = useCreateActionProtocolMutation();
+  const updateProtocol = useUpdateActionProtocolMutation();
+
+  const isEditing = !!protocol;
+  const isPending = createProtocol.isPending || updateProtocol.isPending;
+
+  const [title, setTitle] = useState('');
+  const [trigger, setTrigger] = useState('');
+  const [script, setScript] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setTitle(protocol?.title ?? '');
+      setTrigger(protocol?.trigger ?? '');
+      setScript(protocol?.script ?? '');
+    }
+  }, [open, protocol]);
+
+  const resetAndClose = () => {
+    setTitle('');
+    setTrigger('');
+    setScript('');
+    onClose();
+  };
+
+  const canSave = title.trim().length > 0 && trigger.trim().length > 0 && script.trim().length > 0;
+
+  const handleSave = () => {
+    if (!canSave || isPending) {
+      return;
+    }
+
+    const payload = { title: title.trim(), trigger: trigger.trim(), script: script.trim() };
+
+    const onSuccess = () => {
+      showSnackbar(
+        isEditing ? t('actionProtocol.form.updatedMessage') : t('actionProtocol.form.savedMessage'),
+        'success'
+      );
+      resetAndClose();
+    };
+    const onError = () => showSnackbar(t('actionProtocol.form.errorMessage'), 'error');
+
+    if (isEditing && protocol) {
+      updateProtocol.mutate({ id: protocol.id, protocol: payload }, { onSuccess, onError });
+    } else {
+      createProtocol.mutate(payload, { onSuccess, onError });
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={resetAndClose} maxWidth="sm" fullWidth className="protocol-form-dialog">
+      <DialogContent className="protocol-form-dialog__content">
+        <h2 className="protocol-form-dialog__title">
+          {isEditing ? t('actionProtocol.form.editTitle') : t('actionProtocol.form.createTitle')}
+        </h2>
+
+        <p className="protocol-form-dialog__label">{t('actionProtocol.form.titleLabel')}</p>
+        <input
+          className="protocol-form-dialog__input"
+          type="text"
+          maxLength={255}
+          placeholder={t('actionProtocol.form.titlePlaceholder')}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <p className="protocol-form-dialog__label">{t('actionProtocol.form.triggerLabel')}</p>
+        <input
+          className="protocol-form-dialog__input"
+          type="text"
+          maxLength={255}
+          placeholder={t('actionProtocol.form.triggerPlaceholder')}
+          value={trigger}
+          onChange={(e) => setTrigger(e.target.value)}
+        />
+
+        <p className="protocol-form-dialog__label">{t('actionProtocol.form.scriptLabel')}</p>
+        <textarea
+          className="protocol-form-dialog__textarea"
+          maxLength={5000}
+          placeholder={t('actionProtocol.form.scriptPlaceholder')}
+          value={script}
+          onChange={(e) => setScript(e.target.value)}
+        />
+
+        <div className="protocol-form-dialog__actions">
+          <button type="button" className="protocol-form-dialog__cancel" onClick={resetAndClose}>
+            {t('actionProtocol.form.cancel')}
+          </button>
+          <button
+            type="button"
+            className="protocol-form-dialog__save"
+            disabled={!canSave || isPending}
+            onClick={handleSave}
+          >
+            {isPending ? t('actionProtocol.form.saving') : t('actionProtocol.form.save')}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProtocolFormDialog;

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -24,4 +24,5 @@ export const APP_ROUTES = {
     ENTRIES_EDIT: '/entries/edit/:id',
     STATISTICS: '/statistics',
     QUOTES: '/quotes',
+    PROTOCOLS: '/protocols',
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -79,7 +79,8 @@
     }
   },
   "nav": {
-    "energy": "Energy"
+    "energy": "Energy",
+    "protocols": "Protocols"
   },
   "energyLog": {
     "quickLogTitle": "How's your energy right now?",
@@ -176,6 +177,57 @@
     "updateError": "Failed to update entry.",
     "deleteSuccess": "Entry deleted.",
     "deleteError": "Failed to delete entry."
+  },
+  "actionProtocol": {
+    "list": {
+      "title": "Action Protocols",
+      "subtitle": "Your coping scripts, written in advance and ready when you need them.",
+      "createButton": "New Protocol",
+      "empty": "No protocols yet. Write your first coping script.",
+      "loadMore": "Load more",
+      "triggerLabel": "Trigger:",
+      "usageCount": "Used {{times}} times",
+      "lastUsed": "Last used {{date}}",
+      "markUsedButton": "Mark used",
+      "deleted": "Protocol deleted.",
+      "deleteConfirm": {
+        "title": "Delete protocol",
+        "message": "Are you sure you want to delete this protocol?",
+        "confirm": "Delete",
+        "cancel": "Cancel"
+      }
+    },
+    "form": {
+      "createTitle": "New Action Protocol",
+      "editTitle": "Edit Action Protocol",
+      "titleLabel": "Title",
+      "titlePlaceholder": "e.g. When I feel overwhelmed at work",
+      "triggerLabel": "Trigger / situation",
+      "triggerPlaceholder": "What situation calls for this protocol?",
+      "scriptLabel": "Script / coping steps",
+      "scriptPlaceholder": "Write the steps you'll follow, in order...",
+      "save": "Save",
+      "saving": "Saving...",
+      "cancel": "Cancel",
+      "savedMessage": "Protocol created.",
+      "updatedMessage": "Protocol updated.",
+      "errorMessage": "Could not save your protocol. Please try again."
+    },
+    "markUsed": {
+      "title": "How did it go?",
+      "subtitle": "Rate how effective this protocol was this time.",
+      "notePlaceholder": "Add a note (optional)...",
+      "save": "Save",
+      "saving": "Saving...",
+      "cancel": "Cancel",
+      "savedMessage": "Usage recorded.",
+      "errorMessage": "Could not record usage. Please try again."
+    },
+    "effectiveness": {
+      "WORKED": "It worked",
+      "PARTIAL": "It partially worked",
+      "DIDNT_WORK": "It didn't work"
+    }
   },
   "mimoMethodPage": {
     "hero": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -13,6 +13,7 @@
     "reflection": "Tự chiêm nghiệm",
     "emotion": "Cảm xúc",
     "energy": "Năng lượng",
+    "protocols": "Kịch bản",
     "method": "Phương pháp",
     "journal": "Nhật ký",
     "profile": "Tôi",
@@ -259,6 +260,57 @@
     "updateError": "Không thể cập nhật nhật ký.",
     "deleteSuccess": "Đã xóa nhật ký.",
     "deleteError": "Không thể xóa nhật ký."
+  },
+  "actionProtocol": {
+    "list": {
+      "title": "Kịch bản ứng phó",
+      "subtitle": "Những kịch bản ứng phó bạn viết sẵn, dùng ngay khi cần.",
+      "createButton": "Kịch bản mới",
+      "empty": "Chưa có kịch bản nào. Hãy viết kịch bản đầu tiên của bạn.",
+      "loadMore": "Xem thêm",
+      "triggerLabel": "Tình huống:",
+      "usageCount": "Đã dùng {{times}} lần",
+      "lastUsed": "Dùng lần cuối {{date}}",
+      "markUsedButton": "Đánh dấu đã dùng",
+      "deleted": "Đã xóa kịch bản.",
+      "deleteConfirm": {
+        "title": "Xóa kịch bản",
+        "message": "Bạn có chắc muốn xóa kịch bản này?",
+        "confirm": "Xóa",
+        "cancel": "Hủy"
+      }
+    },
+    "form": {
+      "createTitle": "Kịch bản ứng phó mới",
+      "editTitle": "Chỉnh sửa kịch bản",
+      "titleLabel": "Tiêu đề",
+      "titlePlaceholder": "VD: Khi tôi cảm thấy quá tải trong công việc",
+      "triggerLabel": "Tình huống kích hoạt",
+      "triggerPlaceholder": "Tình huống nào cần đến kịch bản này?",
+      "scriptLabel": "Các bước ứng phó",
+      "scriptPlaceholder": "Viết các bước bạn sẽ làm theo thứ tự...",
+      "save": "Lưu",
+      "saving": "Đang lưu...",
+      "cancel": "Hủy",
+      "savedMessage": "Đã tạo kịch bản.",
+      "updatedMessage": "Đã cập nhật kịch bản.",
+      "errorMessage": "Không thể lưu kịch bản. Vui lòng thử lại."
+    },
+    "markUsed": {
+      "title": "Kết quả thế nào?",
+      "subtitle": "Đánh giá mức độ hiệu quả của kịch bản lần này.",
+      "notePlaceholder": "Thêm ghi chú (tùy chọn)...",
+      "save": "Lưu",
+      "saving": "Đang lưu...",
+      "cancel": "Hủy",
+      "savedMessage": "Đã ghi nhận lần sử dụng.",
+      "errorMessage": "Không thể ghi nhận. Vui lòng thử lại."
+    },
+    "effectiveness": {
+      "WORKED": "Hiệu quả",
+      "PARTIAL": "Hiệu quả một phần",
+      "DIDNT_WORK": "Không hiệu quả"
+    }
   },
   "phuongPhapPage": {
     "hero": {

--- a/src/layouts/MimoHeader/MimoHeader.tsx
+++ b/src/layouts/MimoHeader/MimoHeader.tsx
@@ -93,6 +93,13 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
             {t('nav.energy')}
           </a>
           <a
+            onClick={() => navigate(APP_ROUTES.PROTOCOLS)}
+            className={isActive(APP_ROUTES.PROTOCOLS) ? 'active' : ''}
+            style={{ cursor: 'pointer' }}
+          >
+            {t('nav.protocols')}
+          </a>
+          <a
             onClick={() => navigate(APP_ROUTES.PHUONG_PHAP)}
             className={isActive(APP_ROUTES.PHUONG_PHAP) ? 'active' : ''}
             style={{ cursor: 'pointer' }}
@@ -164,6 +171,7 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
           <a onClick={() => navTo(APP_ROUTES.REFLECTION_ZONE)} style={{ cursor: 'pointer' }}>{t('nav.reflection')}</a>
           <a onClick={() => navTo(APP_ROUTES.EMOTION_ZONE)} style={{ cursor: 'pointer' }}>{t('nav.emotion')}</a>
           <a onClick={() => navTo(APP_ROUTES.ENERGY_HISTORY)} style={{ cursor: 'pointer' }}>{t('nav.energy')}</a>
+          <a onClick={() => navTo(APP_ROUTES.PROTOCOLS)} style={{ cursor: 'pointer' }}>{t('nav.protocols')}</a>
           <a onClick={() => navTo(APP_ROUTES.PHUONG_PHAP)} style={{ cursor: 'pointer' }}>{t('nav.method')}</a>
           <div className="divider" />
           <div className="mobile-language-switcher">

--- a/src/models/actionProtocol.ts
+++ b/src/models/actionProtocol.ts
@@ -1,0 +1,32 @@
+export const EffectivenessLevel = {
+  WORKED: 'WORKED',
+  PARTIAL: 'PARTIAL',
+  DIDNT_WORK: 'DIDNT_WORK'
+} as const;
+
+export type EffectivenessLevel = typeof EffectivenessLevel[keyof typeof EffectivenessLevel];
+
+export interface ActionProtocol {
+  id: string;
+  userId: string;
+  title: string;
+  trigger: string;
+  script: string;
+  usageCount: number;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateActionProtocolRequest {
+  title: string;
+  trigger: string;
+  script: string;
+}
+
+export type UpdateActionProtocolRequest = CreateActionProtocolRequest;
+
+export interface MarkProtocolUsedRequest {
+  effectiveness: EffectivenessLevel;
+  note?: string;
+}

--- a/src/pages/ProtocolsPage/ProtocolsPage.scss
+++ b/src/pages/ProtocolsPage/ProtocolsPage.scss
@@ -1,0 +1,206 @@
+@use '../../styles/_variables' as *;
+
+.protocols-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: calc(var(--header-height-mobile) + var(--spacing-lg)) var(--spacing-md) var(--spacing-3xl);
+
+  &__hero {
+    text-align: center;
+    margin-bottom: var(--spacing-2xl);
+  }
+
+  &__icon {
+    width: 72px;
+    height: 72px;
+    margin: 0 auto var(--spacing-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--garden-parchment);
+    border: 2px solid rgba(212, 168, 67, 0.5);
+    border-radius: 50%;
+    color: var(--c-accent-warm);
+  }
+
+  h1 {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-2xl);
+    color: var(--garden-text);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  p {
+    color: var(--garden-text-muted);
+    font-size: var(--font-size-lg);
+  }
+
+  &__create-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: var(--spacing-md);
+    padding: 12px 24px;
+    background: var(--garden-grass);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: var(--font-weight-semibold);
+
+    &:hover {
+      background: var(--c-primary-hover);
+    }
+  }
+
+  &__content {
+    background: var(--garden-parchment);
+    border-radius: var(--border-radius-lg);
+    padding: var(--spacing-xl);
+    border: 1px solid rgba(166, 123, 91, 0.25);
+    margin-bottom: var(--spacing-xl);
+  }
+
+  &__loading,
+  &__empty,
+  &__empty-state {
+    text-align: center;
+    padding: var(--spacing-2xl);
+    color: var(--garden-text-muted);
+  }
+
+  &__load-more {
+    display: block;
+    margin: var(--spacing-lg) auto 0;
+    padding: 10px 20px;
+    background: none;
+    border: 1px solid rgba(166, 123, 91, 0.4);
+    border-radius: 999px;
+    color: var(--garden-text);
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: none;
+    border: none;
+    color: var(--garden-earth);
+    font-size: var(--font-size-sm);
+    cursor: pointer;
+    padding: 0;
+
+    &:hover {
+      color: var(--garden-grass);
+    }
+  }
+}
+
+.protocols-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+
+  &__item {
+    background: var(--c-surface);
+    border-radius: var(--border-radius-md);
+    padding: var(--spacing-md);
+  }
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+  }
+
+  &__title {
+    margin: 0;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-lg);
+    color: var(--garden-text);
+  }
+
+  &__header-actions {
+    display: flex;
+    gap: var(--spacing-xs);
+    flex-shrink: 0;
+  }
+
+  &__icon-btn {
+    background: none;
+    border: none;
+    color: var(--garden-text-muted);
+    cursor: pointer;
+    padding: var(--spacing-xs);
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    &--danger {
+      color: var(--c-danger);
+    }
+  }
+
+  &__trigger {
+    font-size: var(--font-size-sm);
+    color: var(--garden-text);
+    margin: var(--spacing-xs) 0;
+  }
+
+  &__trigger-label {
+    font-weight: var(--font-weight-semibold);
+    color: var(--garden-text-muted);
+  }
+
+  &__script {
+    font-size: var(--font-size-sm);
+    color: var(--garden-text-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: var(--spacing-xs) 0 var(--spacing-sm);
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+  }
+
+  &__stats {
+    display: flex;
+    flex-direction: column;
+    font-size: var(--font-size-xs);
+    color: var(--garden-text-muted);
+  }
+
+  &__use-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    background: var(--badge-inner-bg);
+    color: var(--badge-inner-text);
+    border: none;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+}

--- a/src/pages/ProtocolsPage/ProtocolsPage.tsx
+++ b/src/pages/ProtocolsPage/ProtocolsPage.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { CircularProgress } from '@mui/material';
+import { LuArrowLeft, LuCheck, LuPencil, LuPlus, LuShieldCheck, LuTrash2 } from 'react-icons/lu';
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import ConfirmDialog from '../../components/ConfirmDialog/ConfirmDialog';
+import ProtocolFormDialog from '../../components/ProtocolFormDialog/ProtocolFormDialog';
+import MarkProtocolUsedDialog from '../../components/MarkProtocolUsedDialog/MarkProtocolUsedDialog';
+import { APP_ROUTES } from '../../constants/route';
+import { useAuth } from '../../providers/AuthProvider';
+import { useSnackbar } from '../../providers/SnackbarProvider';
+import type { ActionProtocol } from '../../models/actionProtocol';
+import { useActionProtocolsInfiniteQuery, useDeleteActionProtocolMutation } from '../../queries/actionProtocolQueryHook';
+import './ProtocolsPage.scss';
+
+const ProtocolsPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const { showSnackbar } = useSnackbar();
+
+  const [formDialogOpen, setFormDialogOpen] = useState(false);
+  const [editingProtocol, setEditingProtocol] = useState<ActionProtocol | null>(null);
+  const [markUsedProtocolId, setMarkUsedProtocolId] = useState<string | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const {
+    data,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useActionProtocolsInfiniteQuery();
+  const deleteProtocol = useDeleteActionProtocolMutation();
+
+  const protocols = useMemo(() => data?.pages.flatMap((page) => page.content) || [], [data]);
+
+  if (!isAuthenticated) {
+    return (
+      <div className="protocols-page">
+        <div className="protocols-page__empty">
+          <p>{t('profilePage.loginRequired')}</p>
+          <button type="button" onClick={() => navigate(APP_ROUTES.LOGIN)}>
+            {t('nav.login')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const handleOpenCreate = () => {
+    setEditingProtocol(null);
+    setFormDialogOpen(true);
+  };
+
+  const handleOpenEdit = (protocol: ActionProtocol) => {
+    setEditingProtocol(protocol);
+    setFormDialogOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!pendingDeleteId) return;
+    deleteProtocol.mutate(pendingDeleteId, {
+      onSuccess: () => showSnackbar(t('actionProtocol.list.deleted'), 'success'),
+      onError: () => showSnackbar(t('actionProtocol.form.errorMessage'), 'error'),
+      onSettled: () => setPendingDeleteId(null),
+    });
+  };
+
+  return (
+    <div className="protocols-page">
+      <Breadcrumb
+        items={[
+          { label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME },
+          { label: t('actionProtocol.list.title') },
+        ]}
+      />
+
+      <section className="protocols-page__hero">
+        <div className="protocols-page__icon">
+          <LuShieldCheck size={28} />
+        </div>
+        <h1>{t('actionProtocol.list.title')}</h1>
+        <p>{t('actionProtocol.list.subtitle')}</p>
+        <button type="button" className="protocols-page__create-btn" onClick={handleOpenCreate}>
+          <LuPlus size={18} />
+          <span>{t('actionProtocol.list.createButton')}</span>
+        </button>
+      </section>
+
+      <section className="protocols-page__content">
+        {isLoading ? (
+          <div className="protocols-page__loading">
+            <CircularProgress size={28} />
+          </div>
+        ) : protocols.length === 0 ? (
+          <div className="protocols-page__empty-state">
+            <p>{t('actionProtocol.list.empty')}</p>
+          </div>
+        ) : (
+          <ul className="protocols-list">
+            {protocols.map((protocol) => (
+              <li key={protocol.id} className="protocols-list__item">
+                <div className="protocols-list__header">
+                  <h3 className="protocols-list__title">{protocol.title}</h3>
+                  <div className="protocols-list__header-actions">
+                    <button
+                      type="button"
+                      className="protocols-list__icon-btn"
+                      aria-label={t('actionProtocol.form.editTitle')}
+                      onClick={() => handleOpenEdit(protocol)}
+                    >
+                      <LuPencil size={16} />
+                    </button>
+                    <button
+                      type="button"
+                      className="protocols-list__icon-btn protocols-list__icon-btn--danger"
+                      aria-label={t('actionProtocol.list.deleteConfirm.confirm')}
+                      onClick={() => setPendingDeleteId(protocol.id)}
+                    >
+                      <LuTrash2 size={16} />
+                    </button>
+                  </div>
+                </div>
+
+                <p className="protocols-list__trigger">
+                  <span className="protocols-list__trigger-label">{t('actionProtocol.list.triggerLabel')}</span> {protocol.trigger}
+                </p>
+                <p className="protocols-list__script">{protocol.script}</p>
+
+                <div className="protocols-list__footer">
+                  <div className="protocols-list__stats">
+                    <span>{t('actionProtocol.list.usageCount', { times: protocol.usageCount })}</span>
+                    {protocol.lastUsedAt && (
+                      <span className="protocols-list__last-used">
+                        {t('actionProtocol.list.lastUsed', { date: new Date(protocol.lastUsedAt).toLocaleString() })}
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    className="protocols-list__use-btn"
+                    onClick={() => setMarkUsedProtocolId(protocol.id)}
+                  >
+                    <LuCheck size={16} />
+                    <span>{t('actionProtocol.list.markUsedButton')}</span>
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {!isLoading && hasNextPage && (
+          <button
+            type="button"
+            className="protocols-page__load-more"
+            disabled={isFetchingNextPage}
+            onClick={() => fetchNextPage()}
+          >
+            {isFetchingNextPage ? <CircularProgress size={16} /> : t('actionProtocol.list.loadMore')}
+          </button>
+        )}
+      </section>
+
+      <button type="button" className="protocols-page__back" onClick={() => navigate(APP_ROUTES.WELCOME)}>
+        <LuArrowLeft size={18} />
+        <span>{t('zonePage.backToGarden')}</span>
+      </button>
+
+      <ProtocolFormDialog
+        open={formDialogOpen}
+        protocol={editingProtocol}
+        onClose={() => setFormDialogOpen(false)}
+      />
+
+      <MarkProtocolUsedDialog
+        open={markUsedProtocolId !== null}
+        protocolId={markUsedProtocolId}
+        onClose={() => setMarkUsedProtocolId(null)}
+      />
+
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        title={t('actionProtocol.list.deleteConfirm.title')}
+        message={t('actionProtocol.list.deleteConfirm.message')}
+        confirmText={t('actionProtocol.list.deleteConfirm.confirm')}
+        cancelText={t('actionProtocol.list.deleteConfirm.cancel')}
+        confirmColor="error"
+        loading={deleteProtocol.isPending}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDeleteId(null)}
+      />
+    </div>
+  );
+};
+
+export default ProtocolsPage;

--- a/src/pages/ProtocolsPage/__tests__/ProtocolsPage.test.tsx
+++ b/src/pages/ProtocolsPage/__tests__/ProtocolsPage.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ProtocolsPage from '../ProtocolsPage';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string, opts?: Record<string, unknown>) => {
+            const labels: Record<string, string> = {
+                'actionProtocol.list.title': 'Action Protocols',
+                'actionProtocol.list.subtitle': 'Your coping scripts, ready when you need them.',
+                'actionProtocol.list.createButton': 'New protocol',
+                'actionProtocol.list.empty': 'No protocols yet.',
+                'breadcrumb.home': 'Home',
+                'zonePage.backToGarden': 'Back to garden',
+                'nav.login': 'Log in',
+                'profilePage.loginRequired': 'Please log in.',
+            };
+            if (key === 'actionProtocol.list.usageCount') return `Used ${opts?.times} times`;
+            return labels[key] ?? key;
+        },
+    }),
+}));
+
+vi.mock('../../../components/ConfirmDialog/ConfirmDialog', () => ({ default: () => null }));
+vi.mock('../../../components/ProtocolFormDialog/ProtocolFormDialog', () => ({ default: () => null }));
+vi.mock('../../../components/MarkProtocolUsedDialog/MarkProtocolUsedDialog', () => ({ default: () => null }));
+
+const mockUseAuth = vi.fn();
+vi.mock('../../../providers/AuthProvider', () => ({
+    useAuth: () => mockUseAuth(),
+}));
+
+const mockUseSnackbar = vi.fn(() => ({ showSnackbar: vi.fn() }));
+vi.mock('../../../providers/SnackbarProvider', () => ({
+    useSnackbar: () => mockUseSnackbar(),
+}));
+
+const mockUseActionProtocolsInfiniteQuery = vi.fn();
+const mockUseDeleteActionProtocolMutation = vi.fn(() => ({ mutate: vi.fn(), isPending: false }));
+vi.mock('../../../queries/actionProtocolQueryHook', () => ({
+    useActionProtocolsInfiniteQuery: () => mockUseActionProtocolsInfiniteQuery(),
+    useDeleteActionProtocolMutation: () => mockUseDeleteActionProtocolMutation(),
+}));
+
+const renderPage = () => render(
+    <MemoryRouter>
+        <ProtocolsPage />
+    </MemoryRouter>
+);
+
+describe('ProtocolsPage', () => {
+    it('shows a login prompt when not authenticated', () => {
+        mockUseAuth.mockReturnValue({ isAuthenticated: false });
+        mockUseActionProtocolsInfiniteQuery.mockReturnValue({
+            data: undefined, isLoading: false, hasNextPage: false, isFetchingNextPage: false, fetchNextPage: vi.fn(),
+        });
+
+        renderPage();
+
+        expect(screen.getByText('Please log in.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();
+    });
+
+    it('shows the empty state when authenticated with no protocols', () => {
+        mockUseAuth.mockReturnValue({ isAuthenticated: true });
+        mockUseActionProtocolsInfiniteQuery.mockReturnValue({
+            data: { pages: [{ content: [], total: 0, nextLink: null }] },
+            isLoading: false, hasNextPage: false, isFetchingNextPage: false, fetchNextPage: vi.fn(),
+        });
+
+        renderPage();
+
+        expect(screen.getByRole('heading', { name: 'Action Protocols' })).toBeInTheDocument();
+        expect(screen.getByText('No protocols yet.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'New protocol' })).toBeInTheDocument();
+    });
+
+    it('renders a protocol card with its usage count', () => {
+        mockUseAuth.mockReturnValue({ isAuthenticated: true });
+        mockUseActionProtocolsInfiniteQuery.mockReturnValue({
+            data: {
+                pages: [{
+                    content: [{
+                        id: 'p1', userId: 'u1', title: 'Deep breaths', trigger: 'Feeling overwhelmed',
+                        script: 'Breathe in for 4, hold for 4, out for 4.', usageCount: 3, lastUsedAt: null,
+                        createdAt: '', updatedAt: '',
+                    }],
+                    total: 1, nextLink: null,
+                }],
+            },
+            isLoading: false, hasNextPage: false, isFetchingNextPage: false, fetchNextPage: vi.fn(),
+        });
+
+        renderPage();
+
+        expect(screen.getByText('Deep breaths')).toBeInTheDocument();
+        expect(screen.getByText('Used 3 times')).toBeInTheDocument();
+    });
+});

--- a/src/queries/actionProtocolQueryHook.ts
+++ b/src/queries/actionProtocolQueryHook.ts
@@ -1,0 +1,89 @@
+import { useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
+import type {
+  ActionProtocol,
+  CreateActionProtocolRequest,
+  MarkProtocolUsedRequest,
+  UpdateActionProtocolRequest
+} from "../models/actionProtocol";
+import { actionProtocolService } from "../services/actionProtocolService";
+import type { PaginatedResponse } from "../models/base";
+
+const ACTION_PROTOCOLS_QUERY_KEY = ['actionProtocols'];
+
+export const useActionProtocolsInfiniteQuery = () => {
+  return useInfiniteQuery<
+    PaginatedResponse<ActionProtocol>,
+    Error,
+    InfiniteData<PaginatedResponse<ActionProtocol>>,
+    string[],
+    string | null
+  >({
+    queryKey: ACTION_PROTOCOLS_QUERY_KEY,
+    initialPageParam: null,
+    staleTime: 1000 * 60 * 5, // 5 mins cache
+
+    queryFn: async ({ pageParam }) => {
+      const nextLink = pageParam as string | undefined;
+
+      const response = await actionProtocolService.getActionProtocols(nextLink);
+
+      return {
+        ...response,
+        content: response.content || [],
+        nextLink: response.nextLink || null,
+        total: response.total || 0
+      };
+    },
+
+    getNextPageParam: (lastPage) => {
+      return lastPage.nextLink || undefined;
+    },
+  });
+};
+
+export const useCreateActionProtocolMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (protocol: CreateActionProtocolRequest) => actionProtocolService.createActionProtocol(protocol),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ACTION_PROTOCOLS_QUERY_KEY });
+    }
+  });
+};
+
+export const useUpdateActionProtocolMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, protocol }: { id: string; protocol: UpdateActionProtocolRequest }) =>
+      actionProtocolService.updateActionProtocol(id, protocol),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ACTION_PROTOCOLS_QUERY_KEY });
+    }
+  });
+};
+
+export const useDeleteActionProtocolMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => actionProtocolService.deleteActionProtocol(id),
+    retry: 3,
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ACTION_PROTOCOLS_QUERY_KEY });
+    },
+  });
+};
+
+export const useMarkActionProtocolUsedMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: MarkProtocolUsedRequest }) =>
+      actionProtocolService.markActionProtocolUsed(id, payload),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ACTION_PROTOCOLS_QUERY_KEY });
+    }
+  });
+};

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -18,6 +18,7 @@ const GardenZonePage = lazy(() => import('../pages/GardenZonePage/GardenZonePage
 const EmotionZonePage = lazy(() => import('../pages/EmotionZonePage/EmotionZonePage'));
 const SignupPage = lazy(() => import('../pages/SignupPage/SignupPage'));
 const EnergyHistoryPage = lazy(() => import('../pages/EnergyHistoryPage/EnergyHistoryPage'));
+const ProtocolsPage = lazy(() => import('../pages/ProtocolsPage/ProtocolsPage'));
 
 export const AppRoutes = () => {
     return (
@@ -43,6 +44,11 @@ export const AppRoutes = () => {
                 <Route path={APP_ROUTES.ENERGY_HISTORY} element={
                     <ProtectedRoute>
                         <EnergyHistoryPage />
+                    </ProtectedRoute>
+                } />
+                <Route path={APP_ROUTES.PROTOCOLS} element={
+                    <ProtectedRoute>
+                        <ProtocolsPage />
                     </ProtectedRoute>
                 } />
 

--- a/src/services/actionProtocolService.ts
+++ b/src/services/actionProtocolService.ts
@@ -1,0 +1,41 @@
+import type { PaginatedResponse } from '../models/base';
+import type {
+  ActionProtocol,
+  CreateActionProtocolRequest,
+  MarkProtocolUsedRequest,
+  UpdateActionProtocolRequest
+} from '../models/actionProtocol';
+import axiosInstance from './axiosSetup';
+
+export const actionProtocolService = {
+  async getActionProtocols(url?: string | null): Promise<PaginatedResponse<ActionProtocol>> {
+    const requestUrl = url || '/protocols?page=0&size=10';
+
+    const { data } = await axiosInstance.get<PaginatedResponse<ActionProtocol>>(requestUrl);
+    return data;
+  },
+
+  async getActionProtocol(id: string): Promise<ActionProtocol> {
+    const { data } = await axiosInstance.get<ActionProtocol>(`/protocols/${id}`);
+    return data;
+  },
+
+  async createActionProtocol(protocol: CreateActionProtocolRequest): Promise<ActionProtocol> {
+    const { data } = await axiosInstance.post<ActionProtocol>('/protocols', protocol);
+    return data;
+  },
+
+  async updateActionProtocol(id: string, protocol: UpdateActionProtocolRequest): Promise<ActionProtocol> {
+    const { data } = await axiosInstance.put<ActionProtocol>(`/protocols/${id}`, protocol);
+    return data;
+  },
+
+  async deleteActionProtocol(id: string): Promise<void> {
+    await axiosInstance.delete(`/protocols/${id}`);
+  },
+
+  async markActionProtocolUsed(id: string, payload: MarkProtocolUsedRequest): Promise<ActionProtocol> {
+    const { data } = await axiosInstance.post<ActionProtocol>(`/protocols/${id}/use`, payload);
+    return data;
+  }
+};


### PR DESCRIPTION
## Summary
- `/protocols`: create/edit/delete coping-script "Action Protocols" (title, trigger, script), each with a "mark used" flow that records an effectiveness rating (Worked / Partial / Didn't work) + optional note, and shows usage count + last-used date.
- Mirrors the Energy Tracking FE vertical (model/service/react-query hooks + dialog pattern).
- Talks to the paired BE PR (`hankimthuy/reflectly-be#<AP-BE-PR>`, `/api/protocols` + `/api/protocols/{id}/use`).
- New: `src/models/actionProtocol.ts`, `src/services/actionProtocolService.ts`, `src/queries/actionProtocolQueryHook.ts` (list key `['actionProtocols']`), `src/pages/ProtocolsPage/`, `src/components/ProtocolFormDialog/`, `src/components/MarkProtocolUsedDialog/`.
- Route `PROTOCOLS = '/protocols'` appended to `route.ts`; nav link added to `MimoHeader` (desktop + mobile menu) — `MobileFooter` intentionally untouched (slot-full).
- i18n: new `actionProtocol` namespace after `entriesPage`, plus `nav.protocols`.

## Test plan
- [x] `npx tsc --noEmit` — only the 4 pre-existing baseline errors
- [x] `npx vitest run` (ProtocolsPage smoke tests: unauthenticated, empty state, rendered card) — 3/3 passing
- [x] i18n dup-key + `actionProtocol` namespace parity check — OK
- [x] No new dependencies; `MobileFooter.tsx` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)