### PR TITLE
feat: rework Method page into a reference/framework page

### DIFF
--- a/src/components/FrameworkPanels/FrameworkPanels.scss
+++ b/src/components/FrameworkPanels/FrameworkPanels.scss
@@ -67,6 +67,36 @@
     }
   }
 
+  &__feature-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: var(--spacing-md);
+    padding: 6px 0;
+    background: none;
+    border: none;
+    color: var(--garden-grass);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+
+    // Explicitly restate the transparent background on hover so this
+    // ghost-style button never inherits the global filled-button hover
+    // background (see src/styles/README.md "Button Hover Convention").
+    &:hover {
+      background-color: transparent;
+      color: var(--c-primary-hover);
+    }
+
+    svg {
+      transition: transform 0.15s ease;
+    }
+
+    &:hover svg {
+      transform: translateX(2px);
+    }
+  }
+
   &__principles {
     margin-top: var(--spacing-2xl);
     padding: var(--spacing-xl);
@@ -91,8 +121,9 @@
       li {
         padding-left: var(--spacing-md);
         position: relative;
-        color: var(--garden-text-muted);
-        font-size: var(--font-size-sm);
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
 
         &::before {
           content: '•';
@@ -102,6 +133,17 @@
         }
       }
     }
+  }
+
+  &__principle-title {
+    color: var(--garden-text);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  &__principle-description {
+    color: var(--garden-text-muted);
+    font-size: var(--font-size-sm);
   }
 
   &--full &__panel {

--- a/src/components/FrameworkPanels/FrameworkPanels.tsx
+++ b/src/components/FrameworkPanels/FrameworkPanels.tsx
@@ -1,11 +1,20 @@
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import { LuArrowRight, LuFilter, LuHeart, LuLeaf } from 'react-icons/lu';
+import { useNavigate } from 'react-router-dom';
+import { APP_ROUTES } from '../../constants/route';
 import useReducedMotion from '../../hooks/useReducedMotion';
 import './FrameworkPanels.scss';
 
 interface FrameworkPanelsProps {
   variant?: 'compact' | 'full';
+  /** Full-variant only: show a small link under each panel pointing to the real feature. */
+  showFeatureLink?: boolean;
+}
+
+interface FrameworkPrinciple {
+  title: string;
+  description: string;
 }
 
 const PANEL_KEYS = ['goOut', 'comeBack', 'filter'] as const;
@@ -14,9 +23,15 @@ const PANEL_ICONS = {
   comeBack: LuHeart,
   filter: LuFilter,
 } as const;
+const PANEL_ROUTES: Record<(typeof PANEL_KEYS)[number], string> = {
+  goOut: APP_ROUTES.ENERGY_HISTORY,
+  comeBack: APP_ROUTES.PROTOCOLS,
+  filter: APP_ROUTES.STATISTICS,
+};
 
-const FrameworkPanels = ({ variant = 'compact' }: FrameworkPanelsProps) => {
+const FrameworkPanels = ({ variant = 'compact', showFeatureLink = false }: FrameworkPanelsProps) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const reducedMotion = useReducedMotion();
 
   const PanelWrapper = reducedMotion ? 'div' : motion.div;
@@ -53,6 +68,16 @@ const FrameworkPanels = ({ variant = 'compact' }: FrameworkPanelsProps) => {
                   </li>
                 ))}
               </ul>
+              {variant === 'full' && showFeatureLink && (
+                <button
+                  type="button"
+                  className="framework-panels__feature-link"
+                  onClick={() => navigate(PANEL_ROUTES[key])}
+                >
+                  <span>{t(`garden.framework.${key}.linkLabel`)}</span>
+                  <LuArrowRight size={14} />
+                </button>
+              )}
             </PanelWrapper>
           );
         })}
@@ -62,8 +87,11 @@ const FrameworkPanels = ({ variant = 'compact' }: FrameworkPanelsProps) => {
         <div className="framework-panels__principles">
           <h3>{t('garden.framework.principlesTitle')}</h3>
           <ul>
-            {(t('garden.framework.principles', { returnObjects: true }) as string[]).map((item) => (
-              <li key={item}>{item}</li>
+            {(t('garden.framework.principles', { returnObjects: true }) as FrameworkPrinciple[]).map((item) => (
+              <li key={item.title}>
+                <span className="framework-panels__principle-title">{item.title}</span>
+                <span className="framework-panels__principle-description">{item.description}</span>
+              </li>
             ))}
           </ul>
         </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -301,6 +301,69 @@
       "DIDNT_WORK": "It didn't work"
     }
   },
+  "garden": {
+    "framework": {
+      "goOut": {
+        "title": "How I go out",
+        "intro": "Before stepping into the outside world, I pause to check my energy and emotions — this is Layer 1 Innerverse.",
+        "steps": ["Log your current energy level (1-10) before you start", "Tag the emotion you're feeling, without judging it right or wrong", "Notice patterns — which activities lift your energy, which drain it", "Choose how to engage based on your actual state right now"],
+        "linkLabel": "View your energy"
+      },
+      "comeBack": {
+        "title": "How I come back",
+        "intro": "When a hard moment hits, I use an Action Protocol — MimoSe's core differentiator — instead of reacting on the spot.",
+        "steps": ["Write the protocol in advance, while your mind is calm", "Use the protocol you prepared as soon as the situation happens", "Mark it as used and record the outcome", "Track its effectiveness over time and adjust if needed"],
+        "linkLabel": "View your protocols"
+      },
+      "filter": {
+        "title": "How I look back",
+        "intro": "The Dashboard and trend charts (Layer 5 Insight & Growth) show me patterns over time — so I can recognize them myself, not have the app conclude for me.",
+        "steps": ["Review your energy trend chart by day and by week", "Compare energy levels across different activities", "Notice the moments when your energy tends to run lowest", "Draw your own conclusions about what's repeating — the next decision is yours"],
+        "linkLabel": "View your dashboard"
+      },
+      "principlesTitle": "Four operating principles",
+      "principles": [
+        { "title": "Accompany, don't theorize", "description": "Every feature ties to a concrete action — not reading material." },
+        { "title": "Self-resolve", "description": "Tools offer question frameworks; the app never gives advice on your behalf." },
+        { "title": "Protocols have a lifecycle", "description": "Action Protocols are tracked and revisited over time, not used once and forgotten." },
+        { "title": "Convenience at the right moment", "description": "1-2 tap interactions are favored, especially in stressful moments." }
+      ]
+    }
+  },
+  "phuongPhapPage": {
+    "hero": {
+      "badge": "Self-leadership foundations",
+      "title": "Why MimoSe <span class=\"highlight\">works this way</span>",
+      "subtitle": "MimoSe is built on Leading Self: understanding and guiding yourself comes before guiding anyone else. This page explains the reasoning behind the features you use every day."
+    },
+    "layers": {
+      "title": "The four layers MimoSe has today",
+      "subtitle": "Every feature you use belongs to one layer of the self-leadership model.",
+      "items": {
+        "foundation": {
+          "label": "Layer 0 · Foundation",
+          "description": "Your account, profile, and journal entries — where all your data begins."
+        },
+        "innerverse": {
+          "label": "Layer 1 · Innerverse",
+          "description": "Energy tracking and emotion tagging — understanding what's happening inside."
+        },
+        "bridge": {
+          "label": "Layer 3 · Bridge",
+          "description": "Action Protocols — the core differentiator that turns insight into concrete action."
+        },
+        "insight": {
+          "label": "Layer 5 · Insight & Growth",
+          "description": "Dashboards and trend charts — looking back at the path you've walked."
+        }
+      }
+    },
+    "cta": {
+      "title": "Ready to apply it?",
+      "subtitle": "Start with your first entry — a journal line, an energy log, or a protocol.",
+      "button": "Start your first entry"
+    }
+  },
   "mimoMethodPage": {
     "hero": {
       "badge": "The Mimo Method",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -60,25 +60,28 @@
     "framework": {
       "goOut": {
         "title": "Tôi ra ngoài như thế nào?",
-        "intro": "Chuẩn bị tâm thế trước khi bước ra thế giới bên ngoài.",
-        "steps": ["Chuẩn bị — biết mình đi đâu và vì sao", "Hiện diện — ở ngay khoảnh khắc này", "Chọn lọc — quyết định điều gì đáng để mở lòng", "Tự do — không mang theo kỳ vọng của người khác"]
+        "intro": "Trước khi bước ra thế giới bên ngoài, tôi dừng lại kiểm tra năng lượng và cảm xúc của mình — đây là Lớp 1 Nội tâm (Innerverse).",
+        "steps": ["Ghi nhanh mức năng lượng hiện tại (1-10) trước khi bắt đầu", "Gắn nhãn cảm xúc đang có, không phán xét đúng hay sai", "Nhận ra mẫu hình — hoạt động nào khiến năng lượng tăng, hoạt động nào khiến cạn kiệt", "Chọn cách tham gia phù hợp với trạng thái thật của mình lúc này"],
+        "linkLabel": "Xem năng lượng của bạn"
       },
       "comeBack": {
         "title": "Tôi quay về như thế nào?",
-        "intro": "Phục hồi và xử lý sau mỗi trải nghiệm bên ngoài.",
-        "steps": ["Mang về bài học và lòng biết ơn", "Buông bỏ stress và kỳ vọng không cần thiết", "Nghỉ ngơi — cho tâm trí và cơ thể hồi phục", "Kết nối lại với giá trị cốt lõi của mình"]
+        "intro": "Khi gặp tình huống khó, tôi dùng Kịch bản ứng phó (Action Protocol) — lõi USP của MimoSe — thay vì phản ứng ngẫu hứng.",
+        "steps": ["Viết kịch bản ứng phó trước, khi đầu óc còn bình tĩnh", "Dùng đúng kịch bản đã chuẩn bị ngay khi tình huống xảy ra", "Đánh dấu đã dùng và ghi lại kết quả", "Theo dõi độ hiệu quả theo thời gian và điều chỉnh kịch bản nếu cần"],
+        "linkLabel": "Xem kịch bản ứng phó của bạn"
       },
       "filter": {
-        "title": "Bộ lọc bên trong – Hàng rào tâm lý",
-        "intro": "Quy trình lọc thông tin và cảm xúc trước khi để chúng vào tâm trí.",
-        "steps": ["Nhận biết — nhận ra điều gì đang ảnh hưởng đến mình", "Đặt câu hỏi — điều này có đúng với mình không?", "Chọn lọc — giữ điều có ích, buông điều không", "Buông bỏ — không ôm hết mọi thứ", "Giữ vững — bám vào giá trị cốt lõi"]
+        "title": "Tôi nhìn lại như thế nào?",
+        "intro": "Bảng thông tin và biểu đồ xu hướng (Lớp 5 Thấu hiểu & Phát triển) cho tôi thấy các mẫu hình theo thời gian — để tôi tự nhận ra, không phải app kết luận thay tôi.",
+        "steps": ["Xem lại biểu đồ xu hướng năng lượng theo ngày, theo tuần", "So sánh mức năng lượng giữa các hoạt động khác nhau", "Nhận ra thời điểm năng lượng thường xuống thấp nhất", "Tự rút ra điều gì đang lặp lại — quyết định tiếp theo là của mình"],
+        "linkLabel": "Xem bảng thông tin của bạn"
       },
-      "principlesTitle": "Bốn nguyên tắc cổng vào",
+      "principlesTitle": "Bốn nguyên tắc vận hành",
       "principles": [
-        "Không phải mọi nhận xét đều đúng.",
-        "Không phải cảm xúc của người khác là trách nhiệm của mình.",
-        "Tôi chọn điều gì để tin, để giữ, để mang về.",
-        "Tôi được quyền khác ý."
+        { "title": "Đồng hành, không lý thuyết", "description": "Mỗi tính năng gắn với một hành động cụ thể — không phải bài đọc lý thuyết." },
+        { "title": "Tự giải quyết", "description": "Công cụ gợi ý khung câu hỏi, không đưa lời khuyên thay bạn." },
+        { "title": "Protocol có vòng đời", "description": "Kịch bản ứng phó được theo dõi và xem lại theo thời gian, không dùng một lần rồi bỏ." },
+        { "title": "Tiện lợi tại đúng khoảnh khắc", "description": "Ưu tiên thao tác 1-2 chạm, đặc biệt trong những lúc căng thẳng." }
       ]
     }
   },
@@ -386,14 +389,36 @@
   },
   "phuongPhapPage": {
     "hero": {
-      "badge": "Phương pháp MimoSe",
-      "title": "Khung <span class=\"highlight\">nhận thức bản thân</span>",
-      "subtitle": "Ba câu hỏi và một bộ lọc giúp bạn ra ngoài có ý thức, quay về an toàn, và hiểu mình sâu hơn mỗi ngày."
+      "badge": "Cơ sở khoa học lãnh đạo bản thân",
+      "title": "Vì sao MimoSe <span class=\"highlight\">vận hành như vậy</span>",
+      "subtitle": "MimoSe được xây dựng theo nguyên lý Leading Self: bạn cần hiểu và dẫn dắt chính mình trước khi dẫn dắt người khác. Trang này giải thích cơ sở đằng sau từng tính năng bạn đang dùng."
+    },
+    "layers": {
+      "title": "Bốn lớp MimoSe đã có",
+      "subtitle": "Mỗi tính năng bạn dùng đều thuộc một lớp trong mô hình lãnh đạo bản thân.",
+      "items": {
+        "foundation": {
+          "label": "Lớp 0 · Nền tảng",
+          "description": "Tài khoản, hồ sơ và nhật ký — nơi mọi dữ liệu của bạn bắt đầu."
+        },
+        "innerverse": {
+          "label": "Lớp 1 · Nội tâm (Innerverse)",
+          "description": "Theo dõi năng lượng và gắn nhãn cảm xúc — hiểu điều đang diễn ra bên trong."
+        },
+        "bridge": {
+          "label": "Lớp 3 · Cầu nối hành động (Bridge)",
+          "description": "Kịch bản ứng phó — lõi USP biến hiểu biết thành hành động cụ thể."
+        },
+        "insight": {
+          "label": "Lớp 5 · Thấu hiểu & Phát triển (Insight & Growth)",
+          "description": "Bảng thông tin và biểu đồ xu hướng — nhìn lại chặng đường đã qua."
+        }
+      }
     },
     "cta": {
-      "title": "Sẵn sàng bước vào vườn?",
-      "subtitle": "Bắt đầu từ góc tự chiêm nghiệm — viết dòng nhật ký đầu tiên.",
-      "button": "Viết nhật ký"
+      "title": "Sẵn sàng áp dụng?",
+      "subtitle": "Bắt đầu bằng ghi nhận đầu tiên của bạn — một dòng nhật ký, một mức năng lượng, hay một kịch bản ứng phó.",
+      "button": "Bắt đầu ghi nhận"
     }
   },
   "zonePage": {

--- a/src/pages/PhuongPhapPage/PhuongPhapPage.scss
+++ b/src/pages/PhuongPhapPage/PhuongPhapPage.scss
@@ -38,6 +38,60 @@
     line-height: var(--line-height-relaxed);
   }
 
+  &__layers {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 var(--spacing-md) var(--spacing-xl);
+    text-align: center;
+
+    h2 {
+      font-family: var(--font-family-heading);
+      font-size: var(--font-size-xl);
+      color: var(--garden-text);
+      margin-bottom: var(--spacing-xs);
+    }
+  }
+
+  &__layers-subtitle {
+    color: var(--garden-text-muted);
+    font-size: var(--font-size-base);
+    margin-bottom: var(--spacing-lg);
+  }
+
+  &__layers-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--spacing-md);
+    text-align: left;
+
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(4, 1fr);
+    }
+  }
+
+  &__layer-card {
+    background: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(91, 140, 90, 0.2);
+    border-radius: var(--border-radius-md);
+    padding: var(--spacing-md);
+    color: var(--garden-grass);
+  }
+
+  &__layer-label {
+    display: block;
+    margin-top: var(--spacing-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--garden-text);
+    font-size: var(--font-size-sm);
+  }
+
+  &__layer-description {
+    margin: var(--spacing-xs) 0 0;
+    color: var(--garden-text-muted);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+  }
+
   &__cta {
     text-align: center;
     padding: var(--spacing-2xl) var(--spacing-md);

--- a/src/pages/PhuongPhapPage/PhuongPhapPage.tsx
+++ b/src/pages/PhuongPhapPage/PhuongPhapPage.tsx
@@ -1,9 +1,18 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { LuArrowRightLeft, LuLayoutGrid, LuSprout, LuTrendingUp } from 'react-icons/lu';
 import FrameworkPanels from '../../components/FrameworkPanels/FrameworkPanels';
 import { APP_ROUTES } from '../../constants/route';
 import { useAuth } from '../../providers/AuthProvider';
 import './PhuongPhapPage.scss';
+
+const LAYER_KEYS = ['foundation', 'innerverse', 'bridge', 'insight'] as const;
+const LAYER_ICONS = {
+  foundation: LuLayoutGrid,
+  innerverse: LuSprout,
+  bridge: LuArrowRightLeft,
+  insight: LuTrendingUp,
+} as const;
 
 const PhuongPhapPage = () => {
   const { t } = useTranslation();
@@ -22,7 +31,28 @@ const PhuongPhapPage = () => {
         <p>{t('phuongPhapPage.hero.subtitle')}</p>
       </section>
 
-      <FrameworkPanels variant="full" />
+      <section className="phuong-phap-page__layers">
+        <h2>{t('phuongPhapPage.layers.title')}</h2>
+        <p className="phuong-phap-page__layers-subtitle">{t('phuongPhapPage.layers.subtitle')}</p>
+        <div className="phuong-phap-page__layers-grid">
+          {LAYER_KEYS.map((key) => {
+            const Icon = LAYER_ICONS[key];
+            return (
+              <div key={key} className="phuong-phap-page__layer-card">
+                <Icon size={20} />
+                <span className="phuong-phap-page__layer-label">
+                  {t(`phuongPhapPage.layers.items.${key}.label`)}
+                </span>
+                <p className="phuong-phap-page__layer-description">
+                  {t(`phuongPhapPage.layers.items.${key}.description`)}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <FrameworkPanels variant="full" showFeatureLink />
 
       <section className="phuong-phap-page__cta">
         <h2>{t('phuongPhapPage.cta.title')}</h2>


### PR DESCRIPTION
## Summary
Reframes `/phuong-phap` from marketing/aspirational copy into a calm "why MimoSe works this way" reference page grounded in the product's layer model:
- New hero copy referencing "Leading Self" directly.
- New layer-model summary block (Layer 0 Foundation, Layer 1 Innerverse, Layer 3 Bridge, Layer 5 Insight & Growth).
- `FrameworkPanels`' 3 panels now explicitly map to real shipped features (Energy, Action Protocol, Dashboard) instead of free-floating aphorisms — Dashboard/`filter` copy stays neutral/observational per the product principle that pattern-reflection features must let the user notice patterns themselves.
- "Gateway principles" replaced with the 4 real product principles, each tied to a concrete app behavior.
- `FrameworkPanels` gains an opt-in `showFeatureLink` prop (full-variant only, defaults `false`) — `MimoLandingPage`'s compact variant is unaffected (verified byte-identical render path).

## Test plan
- [x] `npx tsc --noEmit` — only pre-existing baseline errors, none new
- [x] `npx vitest run` — 120/120 passing
- [x] Confirmed `showFeatureLink` defaults false and compact variant unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)