### PR TITLE
feat: Home Bridge panel + header nav regrouping

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -81,7 +81,34 @@
   "nav": {
     "energy": "Energy",
     "dashboard": "Dashboard",
-    "protocols": "Protocols"
+    "protocols": "Protocols",
+    "journal": "Journal",
+    "groupSpaces": "Spaces",
+    "groupJourney": "Your journey"
+  },
+  "garden": {
+    "bridge": {
+      "heading": "Your bridge to action",
+      "subtitle": "Three small steps to turn insight into action.",
+      "energy": {
+        "title": "Today's energy",
+        "body": "Last logged: level {{level}} · {{days}} days ago",
+        "bodyToday": "Last logged: level {{level}} · today",
+        "empty": "No entries yet — start with one tap",
+        "cta": "View history"
+      },
+      "protocols": {
+        "title": "Your protocols",
+        "body": "{{count}} protocols ready when you need them",
+        "empty": "No protocol yet — create your first",
+        "cta": "View protocols"
+      },
+      "dashboard": {
+        "title": "Look back at your journey",
+        "body": "See your last-7-day trend",
+        "cta": "View dashboard"
+      }
+    }
   },
   "energyLog": {
     "quickLogTitle": "How's your energy right now?",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -19,7 +19,9 @@
     "journal": "Nhật ký",
     "profile": "Tôi",
     "login": "Đăng nhập",
-    "startJourney": "Bắt đầu hành trình"
+    "startJourney": "Bắt đầu hành trình",
+    "groupSpaces": "Không gian",
+    "groupJourney": "Hành trình của bạn"
   },
   "garden": {
     "mapTitle": "Ngôi nhà tâm trí của tôi",
@@ -80,6 +82,28 @@
         "Tôi chọn điều gì để tin, để giữ, để mang về.",
         "Tôi được quyền khác ý."
       ]
+    },
+    "bridge": {
+      "heading": "Cầu nối hành động của bạn",
+      "subtitle": "Ba bước nhỏ để biến nhận thức thành hành động.",
+      "energy": {
+        "title": "Năng lượng hôm nay",
+        "body": "Gần nhất: mức {{level}} · {{days}} ngày trước",
+        "bodyToday": "Gần nhất: mức {{level}} · hôm nay",
+        "empty": "Chưa có bản ghi nào — bắt đầu với 1 chạm",
+        "cta": "Xem lịch sử"
+      },
+      "protocols": {
+        "title": "Kịch bản của bạn",
+        "body": "{{count}} kịch bản đang sẵn sàng",
+        "empty": "Chưa có kịch bản nào — tạo cái đầu tiên",
+        "cta": "Xem kịch bản"
+      },
+      "dashboard": {
+        "title": "Nhìn lại hành trình",
+        "body": "Xem xu hướng 7 ngày qua",
+        "cta": "Xem bảng thông tin"
+      }
     }
   },
   "breadcrumb": {

--- a/src/layouts/MimoHeader/MimoHeader.scss
+++ b/src/layouts/MimoHeader/MimoHeader.scss
@@ -178,6 +178,29 @@
     }
   }
 
+  &__nav-links {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+  }
+
+  &__nav-group-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--garden-text-muted, var(--c-text-muted));
+    opacity: 0.7;
+    white-space: nowrap;
+  }
+
+  &__nav-divider {
+    width: 1px;
+    height: 16px;
+    background: currentColor;
+    opacity: 0.15;
+  }
+
   .btn-cta {
     padding: 10px 24px;
     border-radius: 999px;
@@ -362,6 +385,11 @@
       height: 1px;
       background: var(--c-border);
       margin: 12px 0;
+    }
+
+    .mimo-header__nav-group-label {
+      display: block;
+      margin: 4px 0;
     }
 
     .mobile-user-info {

--- a/src/layouts/MimoHeader/MimoHeader.tsx
+++ b/src/layouts/MimoHeader/MimoHeader.tsx
@@ -64,55 +64,72 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
         </div>
 
         <div className="mimo-header__nav">
-          <a
-            onClick={() => navigate(APP_ROUTES.WELCOME)}
-            className={isActive(APP_ROUTES.WELCOME) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.garden')}
-          </a>
-          <a
-            onClick={() => navigate(APP_ROUTES.REFLECTION_ZONE)}
-            className={isActive(APP_ROUTES.REFLECTION_ZONE) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.reflection')}
-          </a>
-          <a
-            onClick={() => navigate(APP_ROUTES.EMOTION_ZONE)}
-            className={isActive(APP_ROUTES.EMOTION_ZONE) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.emotion')}
-          </a>
-          <a
-            onClick={() => navigate(APP_ROUTES.ENERGY_HISTORY)}
-            className={isActive(APP_ROUTES.ENERGY_HISTORY) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.energy')}
-          </a>
-          <a
-            onClick={() => navigate(APP_ROUTES.STATISTICS)}
-            className={isActive(APP_ROUTES.STATISTICS) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.dashboard')}
-          </a>
-          <a
-            onClick={() => navigate(APP_ROUTES.PROTOCOLS)}
-            className={isActive(APP_ROUTES.PROTOCOLS) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.protocols')}
-          </a>
-          <a
-            onClick={() => navigate(APP_ROUTES.PHUONG_PHAP)}
-            className={isActive(APP_ROUTES.PHUONG_PHAP) ? 'active' : ''}
-            style={{ cursor: 'pointer' }}
-          >
-            {t('nav.method')}
-          </a>
+          <div className="mimo-header__nav-links">
+            <span className="mimo-header__nav-group-label">{t('nav.groupSpaces')}</span>
+            <a
+              onClick={() => navigate(APP_ROUTES.WELCOME)}
+              className={isActive(APP_ROUTES.WELCOME) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.garden')}
+            </a>
+            <a
+              onClick={() => navigate(APP_ROUTES.REFLECTION_ZONE)}
+              className={isActive(APP_ROUTES.REFLECTION_ZONE) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.reflection')}
+            </a>
+            <a
+              onClick={() => navigate(APP_ROUTES.EMOTION_ZONE)}
+              className={isActive(APP_ROUTES.EMOTION_ZONE) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.emotion')}
+            </a>
+
+            <span className="mimo-header__nav-divider" aria-hidden="true" />
+
+            <span className="mimo-header__nav-group-label">{t('nav.groupJourney')}</span>
+            <a
+              onClick={() => navigate(APP_ROUTES.ENERGY_HISTORY)}
+              className={isActive(APP_ROUTES.ENERGY_HISTORY) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.energy')}
+            </a>
+            <a
+              onClick={() => navigate(APP_ROUTES.STATISTICS)}
+              className={isActive(APP_ROUTES.STATISTICS) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.dashboard')}
+            </a>
+            <a
+              onClick={() => navigate(APP_ROUTES.PROTOCOLS)}
+              className={isActive(APP_ROUTES.PROTOCOLS) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.protocols')}
+            </a>
+            <a
+              onClick={() => navigate(APP_ROUTES.ENTRIES_LIST)}
+              className={isActive(APP_ROUTES.ENTRIES_LIST) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.journal')}
+            </a>
+
+            <span className="mimo-header__nav-divider" aria-hidden="true" />
+
+            <a
+              onClick={() => navigate(APP_ROUTES.PHUONG_PHAP)}
+              className={isActive(APP_ROUTES.PHUONG_PHAP) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.method')}
+            </a>
+          </div>
 
           {currentUser ? (
             <div className="mimo-header__user" ref={userMenuRef}>
@@ -174,12 +191,21 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
 
       {isMenuOpen && (
         <div className="mimo-header__mobile-menu">
+          <span className="mimo-header__nav-group-label">{t('nav.groupSpaces')}</span>
           <a onClick={() => navTo(APP_ROUTES.WELCOME)} style={{ cursor: 'pointer' }}>{t('nav.garden')}</a>
           <a onClick={() => navTo(APP_ROUTES.REFLECTION_ZONE)} style={{ cursor: 'pointer' }}>{t('nav.reflection')}</a>
           <a onClick={() => navTo(APP_ROUTES.EMOTION_ZONE)} style={{ cursor: 'pointer' }}>{t('nav.emotion')}</a>
+
+          <div className="divider" />
+
+          <span className="mimo-header__nav-group-label">{t('nav.groupJourney')}</span>
           <a onClick={() => navTo(APP_ROUTES.ENERGY_HISTORY)} style={{ cursor: 'pointer' }}>{t('nav.energy')}</a>
           <a onClick={() => navTo(APP_ROUTES.STATISTICS)} style={{ cursor: 'pointer' }}>{t('nav.dashboard')}</a>
           <a onClick={() => navTo(APP_ROUTES.PROTOCOLS)} style={{ cursor: 'pointer' }}>{t('nav.protocols')}</a>
+          <a onClick={() => navTo(APP_ROUTES.ENTRIES_LIST)} style={{ cursor: 'pointer' }}>{t('nav.journal')}</a>
+
+          <div className="divider" />
+
           <a onClick={() => navTo(APP_ROUTES.PHUONG_PHAP)} style={{ cursor: 'pointer' }}>{t('nav.method')}</a>
           <div className="divider" />
           <div className="mobile-language-switcher">

--- a/src/pages/MimoLandingPage/GardenHero/GardenHero.scss
+++ b/src/pages/MimoLandingPage/GardenHero/GardenHero.scss
@@ -20,14 +20,15 @@
     letter-spacing: 0.15em;
     text-transform: uppercase;
     color: var(--garden-grass);
-    margin-bottom: var(--spacing-xs);
+    margin-bottom: var(--spacing-md);
   }
 
   &__acronym {
     font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-normal);
     color: var(--garden-text-muted);
     letter-spacing: 0.08em;
-    margin-bottom: var(--spacing-md);
+    text-transform: none;
   }
 
   &__slogan {
@@ -47,32 +48,7 @@
     font-size: var(--font-size-lg);
     color: var(--garden-text-muted);
     line-height: var(--line-height-relaxed);
-    margin-bottom: var(--spacing-sm);
-  }
-
-  &__tagline {
-    font-size: var(--font-size-sm);
-    font-style: italic;
-    color: var(--garden-earth);
-    margin-bottom: var(--spacing-xl);
-  }
-
-  &__quote {
-    margin: var(--spacing-xl) 0 0;
-    padding: var(--spacing-lg);
-    background: var(--garden-parchment);
-    border-left: 4px solid var(--garden-grass);
-    border-radius: 0 var(--border-radius-md) var(--border-radius-md) 0;
-    text-align: left;
-
-    p {
-      margin: 0;
-      font-family: var(--font-family-heading);
-      font-style: italic;
-      font-size: var(--font-size-base);
-      color: var(--garden-text);
-      line-height: var(--line-height-relaxed);
-    }
+    margin-bottom: 0;
   }
 
   &__mimo {

--- a/src/pages/MimoLandingPage/GardenHero/GardenHero.tsx
+++ b/src/pages/MimoLandingPage/GardenHero/GardenHero.tsx
@@ -8,14 +8,11 @@ const GardenHero = () => {
   return (
     <section className="garden-hero">
       <div className="garden-hero__content">
-        <p className="garden-hero__brand">{t('brand.name')}</p>
-        <p className="garden-hero__acronym">{t('brand.acronym')}</p>
+        <p className="garden-hero__brand">
+          {t('brand.name')} <span className="garden-hero__acronym">{t('brand.acronym')}</span>
+        </p>
         <h1 className="garden-hero__slogan">{t('brand.slogan')}</h1>
         <p className="garden-hero__description">{t('brand.description')}</p>
-        <p className="garden-hero__tagline">{t('brand.tagline')}</p>
-        <blockquote className="garden-hero__quote">
-          <p>{t('garden.quote')}</p>
-        </blockquote>
       </div>
       <div className="garden-hero__mimo" aria-hidden="true">
         <MimoCharacter theme="bridge" />

--- a/src/pages/MimoLandingPage/MimoLandingPage.tsx
+++ b/src/pages/MimoLandingPage/MimoLandingPage.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import FrameworkPanels from '../../components/FrameworkPanels/FrameworkPanels';
 import GardenMap from '../../components/GardenMap/GardenMap';
 import GardenHero from './GardenHero/GardenHero';
+import TodayBridgePanel from './TodayBridgePanel/TodayBridgePanel';
 import './MimoLandingPage.scss';
 
 const MimoLandingPage = () => {
@@ -11,6 +12,7 @@ const MimoLandingPage = () => {
     <div className="landing-page landing-page--garden">
       <GardenHero />
       <GardenMap />
+      <TodayBridgePanel />
       <FrameworkPanels variant="compact" />
       <footer className="footer">
         <span>{t('brand.footer')}</span>

--- a/src/pages/MimoLandingPage/TodayBridgePanel/TodayBridgePanel.scss
+++ b/src/pages/MimoLandingPage/TodayBridgePanel/TodayBridgePanel.scss
@@ -1,0 +1,97 @@
+@use '../../../styles/_variables' as *;
+
+.today-bridge-panel {
+  padding: var(--spacing-2xl) var(--spacing-md);
+  max-width: 1100px;
+  margin: 0 auto;
+
+  &__title {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-2xl);
+    color: var(--garden-text);
+    text-align: center;
+    margin-bottom: var(--spacing-sm);
+  }
+
+  &__subtitle {
+    text-align: center;
+    color: var(--garden-text-muted);
+    max-width: 560px;
+    margin: 0 auto var(--spacing-xl);
+  }
+
+  &__cards {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--spacing-md);
+
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+    align-items: flex-start;
+    padding: var(--spacing-md);
+    background: var(--garden-parchment);
+    background-color: var(--garden-parchment);
+    border: 1px solid rgba(166, 123, 91, 0.25);
+    border-radius: var(--border-radius-lg);
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-md);
+      // Explicitly restate the resting background so the buggy global
+      // `button:hover` rule (which leaks a dark-brown background) can't take over.
+      background-color: #fbf6e8;
+    }
+
+    h3 {
+      font-family: var(--font-family-heading);
+      font-size: var(--font-size-lg);
+      margin: 0 0 4px;
+      color: var(--garden-text);
+    }
+
+    p {
+      margin: 0;
+      font-size: var(--font-size-sm);
+      color: var(--garden-text-muted);
+      min-height: 1.2em;
+    }
+  }
+
+  &__card-icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--garden-grass-light);
+    color: var(--garden-text);
+    border-radius: var(--border-radius-md);
+  }
+
+  &__card-content {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  &__cta {
+    display: inline-block;
+    margin-top: var(--spacing-sm);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--garden-grass);
+  }
+}

--- a/src/pages/MimoLandingPage/TodayBridgePanel/TodayBridgePanel.tsx
+++ b/src/pages/MimoLandingPage/TodayBridgePanel/TodayBridgePanel.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { LuChartLine, LuShieldCheck, LuZap } from 'react-icons/lu';
+import { useAuth } from '../../../providers/AuthProvider';
+import { APP_ROUTES } from '../../../constants/route';
+import { useEnergyLogsInfiniteQuery } from '../../../queries/energyLogQueryHook';
+import { useActionProtocolsInfiniteQuery } from '../../../queries/actionProtocolQueryHook';
+import './TodayBridgePanel.scss';
+
+const daysAgo = (isoDate: string): number => {
+  const logged = new Date(isoDate);
+  const now = new Date();
+  // Compare calendar-day boundaries, not raw 24h windows, so "this morning" reads as "today".
+  const loggedMidnight = new Date(logged.getFullYear(), logged.getMonth(), logged.getDate());
+  const nowMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diffMs = nowMidnight.getTime() - loggedMidnight.getTime();
+  return Math.max(0, Math.round(diffMs / (1000 * 60 * 60 * 24)));
+};
+
+const TodayBridgePanel = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+
+  // These hooks only ever mount/run once this panel itself renders (i.e. once auth has
+  // resolved and the user is authenticated) — no separate "enabled" gating needed.
+  const { data: energyData, isLoading: isEnergyLoading } = useEnergyLogsInfiniteQuery();
+  const { data: protocolData, isLoading: isProtocolsLoading } = useActionProtocolsInfiniteQuery();
+
+  const latestEnergyLog = energyData?.pages[0]?.content[0] ?? null;
+  const protocolCount = protocolData?.pages[0]?.total ?? 0;
+
+  const energyBody = useMemo(() => {
+    if (!latestEnergyLog) return null;
+    const days = daysAgo(latestEnergyLog.loggedAt);
+    return days === 0
+      ? t('garden.bridge.energy.bodyToday', { level: latestEnergyLog.level })
+      : t('garden.bridge.energy.body', { level: latestEnergyLog.level, days });
+  }, [latestEnergyLog, t]);
+
+  // Anonymous visitors keep seeing today's page exactly as before; also avoid flashing
+  // the panel then hiding it while the auth/profile rehydration query is still in flight.
+  if (isAuthLoading || !isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <section className="today-bridge-panel" aria-label={t('garden.bridge.heading')}>
+      <h2 className="today-bridge-panel__title">{t('garden.bridge.heading')}</h2>
+      <p className="today-bridge-panel__subtitle">{t('garden.bridge.subtitle')}</p>
+
+      <div className="today-bridge-panel__cards">
+        <button
+          type="button"
+          className="today-bridge-panel__card"
+          onClick={() => navigate(APP_ROUTES.ENERGY_HISTORY)}
+        >
+          <div className="today-bridge-panel__card-icon">
+            <LuZap size={22} />
+          </div>
+          <div className="today-bridge-panel__card-content">
+            <h3>{t('garden.bridge.energy.title')}</h3>
+            {isEnergyLoading ? (
+              <p>&nbsp;</p>
+            ) : (
+              <p>{energyBody ?? t('garden.bridge.energy.empty')}</p>
+            )}
+            <span className="today-bridge-panel__cta">{t('garden.bridge.energy.cta')}</span>
+          </div>
+        </button>
+
+        <button
+          type="button"
+          className="today-bridge-panel__card"
+          onClick={() => navigate(APP_ROUTES.PROTOCOLS)}
+        >
+          <div className="today-bridge-panel__card-icon">
+            <LuShieldCheck size={22} />
+          </div>
+          <div className="today-bridge-panel__card-content">
+            <h3>{t('garden.bridge.protocols.title')}</h3>
+            {isProtocolsLoading ? (
+              <p>&nbsp;</p>
+            ) : protocolCount > 0 ? (
+              <p>{t('garden.bridge.protocols.body', { count: protocolCount })}</p>
+            ) : (
+              <p>{t('garden.bridge.protocols.empty')}</p>
+            )}
+            <span className="today-bridge-panel__cta">{t('garden.bridge.protocols.cta')}</span>
+          </div>
+        </button>
+
+        <button
+          type="button"
+          className="today-bridge-panel__card"
+          onClick={() => navigate(APP_ROUTES.STATISTICS)}
+        >
+          <div className="today-bridge-panel__card-icon">
+            <LuChartLine size={22} />
+          </div>
+          <div className="today-bridge-panel__card-content">
+            <h3>{t('garden.bridge.dashboard.title')}</h3>
+            <p>{t('garden.bridge.dashboard.body')}</p>
+            <span className="today-bridge-panel__cta">{t('garden.bridge.dashboard.cta')}</span>
+          </div>
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default TodayBridgePanel;


### PR DESCRIPTION
## Summary
- Trims `GardenHero` to brand/acronym + slogan + description (drops the redundant tagline and the aphoristic quote blockquote) — no CTA added here, the actionable surface moves below.
- New `TodayBridgePanel` (auth-gated, renders exactly nothing for anonymous visitors) inserted between `GardenMap` and `FrameworkPanels(compact)` on the home page: 3 cards surfacing Energy (last logged level + relative day), Protocols (active count), and Dashboard (static prompt) — reusing existing services/hooks, zero new API calls. Does not touch `gardenMapScene.ts`/`GardenScene3D.tsx`/`gardenZones.ts` (avoids conflicting with unrelated in-progress 3D layout work).
- Regroups `MimoHeader`'s 7 flat links into 2 labeled clusters ("Spaces": Garden/Reflection/Emotion; "Your journey": Energy/Dashboard/Protocols/**+ new Entries link**, closing a gap where `/entries/list` had no desktop nav entry) + Method standalone — desktop and mobile menu both updated, static layout (no new dropdown component).

## Test plan
- [x] `npx tsc --noEmit` — only pre-existing baseline errors, none new
- [x] `npx vitest run` — 120/120 passing including `MobileFooter.test.tsx`
- [x] Confirmed zero changes to `gardenMapScene.ts`/`GardenScene3D.tsx`/`gardenZones.ts`/`GardenMap.tsx`/`FrameworkPanels.tsx`/`MobileFooter.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)