### PR TITLE
feat: rebrand to Aura Self AI, full i18n, responsive fixes, unified button system

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="MimoSe — Lắng nghe & Lãnh đạo chính mình. Khu vườn tâm trí cho nhận thức bản thân." />
+    <meta name="description" content="Aura Self AI — AI Coach trò chuyện giúp bạn thấu hiểu chính mình và tự động dựng nên bản đồ mối quan hệ." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Lora:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet" />
-    <title>MimoSe — Lắng nghe & Lãnh đạo chính mình</title>
+    <title>Aura Self AI — Thấu hiểu chính mình cùng AI Coach</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,102 @@
+import { forwardRef } from 'react';
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
+import { Link, type LinkProps } from 'react-router-dom';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonShape = 'rounded' | 'pill';
+
+/**
+ * The one shared button style for the whole app (Tailwind-only, using the coach-* palette
+ * already established for the AI Coach era). Every clickable action — CTA, form submit,
+ * icon-text button, nav-styled link — should render through this component instead of a
+ * hand-rolled className string, so a button that forgets one Tailwind property can never
+ * fall back to the legacy global `button` CSS reset and show up in the wrong color.
+ */
+// Every variant explicitly sets a `hover:bg-*` (even when it's the same as rest state, e.g.
+// `hover:bg-transparent`) — never leave the hover background undeclared. Without it, nothing
+// competes with the legacy global `button:hover { background: var(--c-secondary) }` reset in
+// index.scss, which then silently paints the button brown on hover (the exact bug this
+// component exists to eliminate — see index.scss's `@layer base` comment for the full story).
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary: 'bg-coach-primary text-white hover:bg-coach-primary-light disabled:hover:bg-coach-primary',
+  secondary: 'border border-coach-border bg-coach-surface text-coach-text hover:bg-coach-bg disabled:hover:bg-coach-surface',
+  ghost: 'bg-transparent text-coach-primary hover:bg-transparent hover:underline disabled:hover:bg-transparent disabled:hover:no-underline',
+  danger: 'bg-transparent text-red-500 hover:bg-red-50 disabled:hover:bg-transparent',
+};
+
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-xs gap-1',
+  md: 'px-4 py-2 text-sm gap-1.5',
+  lg: 'px-7 py-3 text-base gap-2',
+};
+
+const SHAPE_CLASSES: Record<ButtonShape, string> = {
+  rounded: 'rounded-lg',
+  pill: 'rounded-full',
+};
+
+const BASE_CLASSES =
+  'inline-flex items-center justify-center font-medium transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-40';
+
+function buttonClassName(
+  variant: ButtonVariant,
+  size: ButtonSize,
+  shape: ButtonShape,
+  className: string,
+) {
+  return [BASE_CLASSES, VARIANT_CLASSES[variant], SIZE_CLASSES[size], SHAPE_CLASSES[shape], className]
+    .filter(Boolean)
+    .join(' ');
+}
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  shape?: ButtonShape;
+}
+
+/** Renders a real `<button>`. Use for form submits and in-page actions. */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', size = 'md', shape = 'rounded', className = '', type = 'button', ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={buttonClassName(variant, size, shape, className)}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';
+
+interface ButtonLinkProps extends LinkProps {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  shape?: ButtonShape;
+}
+
+/** Renders a react-router `<Link>` styled identically to `Button`. Use for navigation CTAs. */
+export const ButtonLink = ({
+  variant = 'primary',
+  size = 'md',
+  shape = 'rounded',
+  className = '',
+  ...props
+}: ButtonLinkProps) => <Link className={buttonClassName(variant, size, shape, className)} {...props} />;
+
+interface ButtonAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  shape?: ButtonShape;
+}
+
+/** Renders a plain `<a>` styled identically to `Button`. Use for external/placeholder links. */
+export const ButtonAnchor = ({
+  variant = 'primary',
+  size = 'md',
+  shape = 'rounded',
+  className = '',
+  ...props
+}: ButtonAnchorProps) => <a className={buttonClassName(variant, size, shape, className)} {...props} />;
+
+export default Button;

--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -1,5 +1,6 @@
-import { useState, type KeyboardEvent } from 'react';
+import { useRef, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '../Button/Button';
 
 interface MessageInputProps {
   onSend: (content: string) => void;
@@ -9,12 +10,21 @@ interface MessageInputProps {
 const MessageInput = ({ onSend, disabled }: MessageInputProps) => {
   const { t } = useTranslation();
   const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const resizeToContent = (el: HTMLTextAreaElement) => {
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
 
   const handleSend = () => {
     const trimmed = value.trim();
     if (!trimmed || disabled) return;
     onSend(trimmed);
     setValue('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -27,22 +37,21 @@ const MessageInput = ({ onSend, disabled }: MessageInputProps) => {
   return (
     <div className="flex items-end gap-2 border-t border-coach-border bg-coach-surface px-4 py-3">
       <textarea
+        ref={textareaRef}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => {
+          setValue(e.target.value);
+          resizeToContent(e.target);
+        }}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         rows={1}
-        placeholder={t('coach.inputPlaceholder', 'Chia sẻ điều bạn đang nghĩ...') as string}
-        className="max-h-32 flex-1 resize-none rounded-xl border border-coach-border bg-coach-bg px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary disabled:opacity-50"
+        placeholder={t('coach.inputPlaceholder') as string}
+        className="max-h-32 flex-1 resize-none overflow-y-auto rounded-xl border border-coach-border bg-coach-bg px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary disabled:opacity-50"
       />
-      <button
-        type="button"
-        onClick={handleSend}
-        disabled={disabled || !value.trim()}
-        className="rounded-xl bg-coach-primary px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-40"
-      >
-        {t('coach.send', 'Gửi')}
-      </button>
+      <Button variant="primary" onClick={handleSend} disabled={disabled || !value.trim()}>
+        {t('coach.send')}
+      </Button>
     </div>
   );
 };

--- a/src/components/CoreValuesCard/CoreValuesCard.tsx
+++ b/src/components/CoreValuesCard/CoreValuesCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CORE_VALUE_KEYS } from '../../constants/coreValues';
+import { Button } from '../Button/Button';
 
 interface CoreValuesCardProps {
   coreValues: string[] | undefined;
@@ -55,16 +56,12 @@ const CoreValuesCard = ({ coreValues, onSave, autoEdit = false, className = '' }
     <section className={`rounded-2xl border border-coach-border bg-coach-surface p-4 ${className}`}>
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-coach-text">
-          {t('profilePage.coreValues.title', 'Giá trị cốt lõi')}
+          {t('profilePage.coreValues.title')}
         </h3>
         {!isEditing && (
-          <button
-            type="button"
-            onClick={startEdit}
-            className="text-xs font-medium text-coach-primary hover:underline"
-          >
-            {hasValues ? t('profilePage.coreValues.edit', 'Chỉnh sửa') : t('profilePage.coreValues.add', '+ Thiết lập')}
-          </button>
+          <Button variant="ghost" size="sm" onClick={startEdit}>
+            {hasValues ? t('profilePage.coreValues.edit') : t('profilePage.coreValues.add')}
+          </Button>
         )}
       </div>
 
@@ -90,22 +87,12 @@ const CoreValuesCard = ({ coreValues, onSave, autoEdit = false, className = '' }
             })}
           </div>
           <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={saving}
-              className="rounded-lg bg-coach-primary px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
-            >
-              {saving ? t('onboarding.submitting', 'Đang lưu...') : t('profilePage.coreValues.save', 'Lưu')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setIsEditing(false)}
-              disabled={saving}
-              className="rounded-lg border border-coach-border px-3 py-1.5 text-xs font-medium text-coach-text-muted"
-            >
-              {t('onboarding.back', 'Hủy')}
-            </button>
+            <Button variant="primary" size="sm" onClick={handleSave} disabled={saving}>
+              {saving ? t('onboarding.submitting') : t('profilePage.coreValues.save')}
+            </Button>
+            <Button variant="secondary" size="sm" onClick={() => setIsEditing(false)} disabled={saving}>
+              {t('profilePage.coreValues.cancel')}
+            </Button>
           </div>
         </div>
       ) : hasValues ? (
@@ -121,7 +108,7 @@ const CoreValuesCard = ({ coreValues, onSave, autoEdit = false, className = '' }
         </div>
       ) : (
         <p className="mt-3 text-xs text-coach-text-muted">
-          {t('profilePage.coreValues.empty', 'Chưa thiết lập — Coach sẽ hiểu bạn hơn nếu bạn cho biết điều gì quan trọng với mình.')}
+          {t('profilePage.coreValues.empty')}
         </p>
       )}
     </section>

--- a/src/components/FrameworkPanels/FrameworkPanels.scss
+++ b/src/components/FrameworkPanels/FrameworkPanels.scss
@@ -67,35 +67,6 @@
     }
   }
 
-  &__feature-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin-top: var(--spacing-md);
-    padding: 6px 0;
-    background: none;
-    border: none;
-    color: var(--garden-grass);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
-    cursor: pointer;
-
-    // Explicitly restate the transparent background on hover so this
-    // ghost-style button never inherits the global filled-button hover
-    // background (see src/styles/README.md "Button Hover Convention").
-    &:hover {
-      background-color: transparent;
-      color: var(--c-primary-hover);
-    }
-
-    svg {
-      transition: transform 0.15s ease;
-    }
-
-    &:hover svg {
-      transform: translateX(2px);
-    }
-  }
 
   &__principles {
     margin-top: var(--spacing-2xl);

--- a/src/components/FrameworkPanels/FrameworkPanels.tsx
+++ b/src/components/FrameworkPanels/FrameworkPanels.tsx
@@ -1,7 +1,9 @@
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { LuArrowRight, LuFilter, LuHeart, LuLeaf } from 'react-icons/lu';
+import { LuArrowRight, LuLayoutDashboard, LuMessageCircle, LuUsers } from 'react-icons/lu';
 import useReducedMotion from '../../hooks/useReducedMotion';
+import { APP_ROUTES } from '../../constants/route';
+import { ButtonLink } from '../Button/Button';
 import './FrameworkPanels.scss';
 
 interface FrameworkPanelsProps {
@@ -15,10 +17,15 @@ interface FrameworkPrinciple {
 
 const PANEL_KEYS = ['goOut', 'comeBack', 'filter'] as const;
 const PANEL_ICONS = {
-  goOut: LuLeaf,
-  comeBack: LuHeart,
-  filter: LuFilter,
+  goOut: LuMessageCircle,
+  comeBack: LuUsers,
+  filter: LuLayoutDashboard,
 } as const;
+const PANEL_ROUTES: Record<(typeof PANEL_KEYS)[number], string> = {
+  goOut: APP_ROUTES.COACH_CHAT,
+  comeBack: APP_ROUTES.DASHBOARD,
+  filter: APP_ROUTES.DASHBOARD,
+};
 
 const FrameworkPanels = ({ variant = 'compact' }: FrameworkPanelsProps) => {
   const { t } = useTranslation();
@@ -58,6 +65,10 @@ const FrameworkPanels = ({ variant = 'compact' }: FrameworkPanelsProps) => {
                   </li>
                 ))}
               </ul>
+              <ButtonLink to={PANEL_ROUTES[key]} variant="ghost" size="sm" className="!px-0 mt-3">
+                {t(`garden.framework.${key}.linkLabel`)}
+                <LuArrowRight size={14} />
+              </ButtonLink>
             </PanelWrapper>
           );
         })}

--- a/src/components/InsightTimeline/InsightTimelineList.tsx
+++ b/src/components/InsightTimeline/InsightTimelineList.tsx
@@ -9,13 +9,13 @@ const InsightTimelineList = () => {
   const insights = data?.pages.flatMap((page) => page.content) ?? [];
 
   if (isLoading) {
-    return <p className="text-sm text-coach-text-muted">{t('dashboard.loading', 'Đang tải...')}</p>;
+    return <p className="text-sm text-coach-text-muted">{t('dashboard.loading')}</p>;
   }
 
   if (insights.length === 0) {
     return (
       <div className="rounded-2xl border border-coach-border bg-coach-surface p-8 text-center text-sm text-coach-text-muted">
-        {t('dashboard.insightsEmpty', 'Chưa có insight nào — hãy trò chuyện với Coach để bắt đầu.')}
+        {t('dashboard.insightsEmpty')}
       </div>
     );
   }
@@ -33,7 +33,7 @@ const InsightTimelineList = () => {
           disabled={isFetchingNextPage}
           className="mt-1 self-center rounded-lg border border-coach-border px-4 py-1.5 text-xs font-medium text-coach-text-muted hover:bg-coach-bg disabled:opacity-40"
         >
-          {isFetchingNextPage ? t('dashboard.loading', 'Đang tải...') : t('dashboard.loadMore', 'Tải thêm')}
+          {isFetchingNextPage ? t('dashboard.loading') : t('dashboard.loadMore')}
         </button>
       )}
     </div>

--- a/src/components/MimoCharacter/MimoCharacter.tsx
+++ b/src/components/MimoCharacter/MimoCharacter.tsx
@@ -13,7 +13,7 @@ const MimoCharacter = ({ theme = 'bridge', className = '' }: MimoCharacterProps)
       <div className={`mimo-character__body mimo-character__body--${theme}`}>
          <img 
             src={mimoImage} 
-            alt="Mimo Mascot" 
+            alt="Aura mascot"
             className="mimo-character__image"
          />
          

--- a/src/components/NotFound/NotFound.scss
+++ b/src/components/NotFound/NotFound.scss
@@ -38,22 +38,4 @@
     gap: var(--spacing-md);
   }
 
-  &__btn {
-    padding: 12px 24px;
-    border-radius: 999px;
-    font-size: var(--font-size-base);
-    cursor: pointer;
-    border: none;
-    transition: transform 0.2s ease;
-
-    &--primary {
-      background-color: var(--garden-grass);
-      color: white;
-
-      &:hover {
-        background-color: var(--c-primary-hover);
-        transform: translateY(-2px);
-      }
-    }
-  }
 }

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { APP_ROUTES } from '../../constants/route';
+import { Button } from '../Button/Button';
 import './NotFound.scss';
 
 const NotFoundPage: React.FC = () => {
@@ -15,9 +16,9 @@ const NotFoundPage: React.FC = () => {
       <p className="not-found-page__message">{t('notFound.subtitle')}</p>
 
       <div className="not-found-page__actions">
-        <button type="button" onClick={() => navigate(APP_ROUTES.WELCOME)} className="not-found-page__btn not-found-page__btn--primary">
+        <Button variant="primary" size="md" shape="pill" onClick={() => navigate(APP_ROUTES.WELCOME)}>
           {t('notFound.back')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/PersonForm/PersonForm.tsx
+++ b/src/components/PersonForm/PersonForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { CreatePersonRequest, RelationshipType } from '../../models/person';
+import { Button } from '../Button/Button';
 
 const RELATIONSHIP_TYPES: RelationshipType[] = ['FAMILY', 'FRIEND', 'PARTNER', 'COLLEAGUE', 'MANAGER', 'OTHER'];
 
@@ -25,7 +26,7 @@ const PersonForm = ({ initialValue, onSubmit, onCancel, submitLabel }: PersonFor
 
   const handleSubmit = async () => {
     if (!name.trim()) {
-      setError(t('dashboard.person.nameRequired', 'Nhập tên trước đã.'));
+      setError(t('dashboard.person.nameRequired'));
       return;
     }
     setError(null);
@@ -33,7 +34,7 @@ const PersonForm = ({ initialValue, onSubmit, onCancel, submitLabel }: PersonFor
     try {
       await onSubmit({ name: name.trim(), relationshipType, notes: notes.trim() || undefined });
     } catch {
-      setError(t('dashboard.person.saveError', 'Có lỗi xảy ra, vui lòng thử lại.'));
+      setError(t('dashboard.person.saveError'));
     } finally {
       setSaving(false);
     }
@@ -46,7 +47,7 @@ const PersonForm = ({ initialValue, onSubmit, onCancel, submitLabel }: PersonFor
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder={t('onboarding.namePlaceholder', 'Tên')}
+          placeholder={t('onboarding.namePlaceholder')}
           className="flex-1 rounded-lg border border-coach-border bg-coach-surface px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
         />
         <select
@@ -64,28 +65,18 @@ const PersonForm = ({ initialValue, onSubmit, onCancel, submitLabel }: PersonFor
       <textarea
         value={notes}
         onChange={(e) => setNotes(e.target.value)}
-        placeholder={t('dashboard.person.notesPlaceholder', 'Ghi chú (tuỳ chọn)')}
+        placeholder={t('dashboard.person.notesPlaceholder')}
         rows={2}
         className="rounded-lg border border-coach-border bg-coach-surface px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
       />
       {error && <p className="text-xs text-red-500">{error}</p>}
       <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={saving}
-          className="rounded-lg bg-coach-primary px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
-        >
-          {saving ? t('onboarding.submitting', 'Đang lưu...') : submitLabel}
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={saving}
-          className="rounded-lg border border-coach-border px-3 py-1.5 text-xs font-medium text-coach-text-muted"
-        >
-          {t('onboarding.back', 'Hủy')}
-        </button>
+        <Button variant="primary" size="sm" onClick={handleSubmit} disabled={saving}>
+          {saving ? t('onboarding.submitting') : submitLabel}
+        </Button>
+        <Button variant="secondary" size="sm" onClick={onCancel} disabled={saving}>
+          {t('dashboard.person.cancel')}
+        </Button>
       </div>
     </div>
   );

--- a/src/components/RelationshipMap/RelationshipMap.tsx
+++ b/src/components/RelationshipMap/RelationshipMap.tsx
@@ -64,9 +64,14 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
     );
   }
 
+  const selectPerson = (personId: string) => {
+    setIsEditing(false);
+    setSelectedId(personId === selectedId ? null : personId);
+  };
+
   return (
     <div className="rounded-2xl border border-coach-border bg-coach-surface p-4">
-      <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="w-full" role="img">
+      <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="w-full">
         {nodes.map(({ person, x, y }) => (
           <line
             key={`line-${person.id}`}
@@ -81,16 +86,23 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
 
         <circle cx={CENTER} cy={CENTER} r={30} fill="var(--color-coach-primary)" />
         <text x={CENTER} y={CENTER + 5} textAnchor="middle" fontSize={13} fill="white" fontWeight={600}>
-          {t('dashboard.you', 'Bạn')}
+          {t('dashboard.you')}
         </text>
 
         {nodes.map(({ person, x, y }) => (
           <g
             key={person.id}
             className="cursor-pointer"
-            onClick={() => {
-              setIsEditing(false);
-              setSelectedId(person.id === selectedId ? null : person.id);
+            tabIndex={0}
+            role="button"
+            aria-label={person.name}
+            aria-pressed={person.id === selectedId}
+            onClick={() => selectPerson(person.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                selectPerson(person.id);
+              }
             }}
           >
             <circle
@@ -115,7 +127,7 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
         <div className="mt-3">
           <PersonForm
             initialValue={{ name: selected.name, relationshipType: selected.relationshipType, notes: selected.notes ?? undefined }}
-            submitLabel={t('dashboard.person.save', 'Lưu')}
+            submitLabel={t('dashboard.person.save')}
             onCancel={() => setIsEditing(false)}
             onSubmit={async (person) => {
               await updatePerson.mutateAsync({ id: selected.id, person });
@@ -134,7 +146,7 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
               onClick={() => setIsEditing(true)}
               className="text-xs font-medium text-coach-primary hover:underline"
             >
-              {t('dashboard.person.edit', 'Chỉnh sửa')}
+              {t('dashboard.person.edit')}
             </button>
           </div>
           {selected.notes && <p className="mt-1 text-coach-text-muted">{selected.notes}</p>}
@@ -142,7 +154,7 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
             <p className="mt-1 text-coach-text-muted">{selected.nudgeText}</p>
           ) : (
             <p className="mt-1 text-coach-text-muted">
-              {t('dashboard.noNudge', 'Mối quan hệ này đang ổn định.')}
+              {t('dashboard.noNudge')}
             </p>
           )}
         </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -12,11 +12,15 @@ const resources = {
   }
 };
 
+const LANGUAGE_STORAGE_KEY = 'app_language';
+const storedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+const initialLanguage = storedLanguage === 'en' || storedLanguage === 'vi' ? storedLanguage : 'vi';
+
 i18n
   .use(initReactI18next)
   .init({
     resources,
-    lng: 'vi',
+    lng: initialLanguage,
     fallbackLng: 'vi',
     debug: import.meta.env.DEV,
     interpolation: {
@@ -26,5 +30,9 @@ i18n
       useSuspense: false // Disable suspense mode
     }
   });
+
+i18n.on('languageChanged', (lng) => {
+  localStorage.setItem(LANGUAGE_STORAGE_KEY, lng);
+});
 
 export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,51 +1,190 @@
 {
+  "onboarding": {
+    "step": "Step {{current}}/2",
+    "step1Title": "What matters to you?",
+    "step1Subtitle": "Pick the core values that resonate with you most.",
+    "step2Title": "Who matters to you?",
+    "step2Subtitle": "Add 3-5 people you'd like to track your relationship with.",
+    "selectAtLeastOne": "Select at least one value to continue.",
+    "addAtLeastOnePerson": "Add at least one person, or tap \"Skip, go straight to Coach\".",
+    "submitError": "Something went wrong, please try again.",
+    "namePlaceholder": "Name",
+    "removePerson": "Remove",
+    "addPerson": "+ Add person",
+    "back": "Back",
+    "continue": "Continue",
+    "submitting": "Saving...",
+    "finish": "Finish",
+    "skipStep": "Skip this step",
+    "skipToCoach": "Skip, go straight to Coach",
+    "value": {
+      "honesty": "Honesty",
+      "family": "Family",
+      "freedom": "Freedom",
+      "creativity": "Creativity",
+      "connection": "Connection",
+      "growth": "Growth",
+      "balance": "Balance",
+      "courage": "Courage",
+      "peace": "Peace",
+      "contribution": "Contribution",
+      "achievement": "Achievement",
+      "learning": "Learning"
+    },
+    "relationshipType": {
+      "FAMILY": "Family",
+      "FRIEND": "Friend",
+      "PARTNER": "Partner/Spouse",
+      "COLLEAGUE": "Colleague",
+      "MANAGER": "Manager",
+      "OTHER": "Other"
+    }
+  },
+  "coach": {
+    "title": "Coach",
+    "subtitle": "A space to dig deeper into your own thinking",
+    "inputPlaceholder": "Share what's on your mind...",
+    "send": "Send",
+    "endSession": "End session",
+    "emptyState": "Start by sharing what's on your mind right now.",
+    "sendError": "Couldn't send your message right now. Please try again."
+  },
+  "brand": {
+    "name": "Aura Self AI",
+    "acronym": "AI Coach for Self-Understanding",
+    "slogan": "Understand yourself, one conversation at a time",
+    "description": "Aura Self AI is an AI Coach that talks with you — automatically building your relationship map and personal insights, with no judgment and no advice imposed on you.",
+    "tagline": "Talk to understand yourself, every day.",
+    "footer": "© 2026 Aura Self AI. Walking with you on the path of Self-Understanding & Self-Leadership.",
+    "welcome": "Welcome back to Aura Self AI.",
+    "ctaLoggedOut": "Start chatting with your Coach",
+    "ctaLoggedIn": "Continue the conversation"
+  },
+  "nav": {
+    "coach": "Coach",
+    "garden": "Home",
+    "reflection": "Reflection",
+    "emotion": "Emotion",
+    "energy": "Energy",
+    "dashboard": "Insights",
+    "protocols": "Protocols",
+    "method": "Method",
+    "journal": "Reflectly",
+    "profile": "Me",
+    "login": "Log In",
+    "startJourney": "Start your journey",
+    "groupSpaces": "Spaces",
+    "groupJourney": "Your journey"
+  },
+  "garden": {
+    "mapTitle": "My Mind Space",
+    "mapSubtitle": "Pick a corner to connect with and understand yourself.",
+    "mapAlt": "Map with a central house and four surrounding areas",
+    "comingSoon": "Coming soon",
+    "quote": "I can't control what happens to me, but I always have the choice of how I listen and respond.",
+    "legend": {
+      "goOut": "Reach out and experience",
+      "comeBack": "Take time to recover"
+    },
+    "zones": {
+      "mind": {
+        "title": "Mind",
+        "description": "A quiet corner — where you return to find your balance."
+      },
+      "reflection": {
+        "title": "Reflection",
+        "description": "A corner to look back — for deep dialogue with yourself."
+      },
+      "creativity": {
+        "title": "Creativity",
+        "description": "A corner to express — turning emotion into creative flow."
+      },
+      "connection": {
+        "title": "Relationships",
+        "description": "A corner to connect — recognizing the sources of energy around you."
+      },
+      "emotion": {
+        "title": "Emotion",
+        "description": "A corner to be present — naming and welcoming every emotion."
+      },
+      "filter": {
+        "title": "Value filter",
+        "description": "A corner to sift through — actively choosing what to keep and what to release."
+      }
+    },
+    "framework": {
+      "goOut": {
+        "title": "Chat with your AI Coach",
+        "intro": "A Socratic conversation space — the Coach asks open questions so you find your own answers.",
+        "steps": ["Share what's on your mind, no preparation needed.", "The Coach remembers what matters to you, conversation by conversation."],
+        "linkLabel": "Start chatting"
+      },
+      "comeBack": {
+        "title": "Your relationship map",
+        "intro": "Built automatically from what you share — so you can see clearly who energizes you and who drains you.",
+        "steps": ["No manual data entry — the Coach recognizes people as you talk.", "Add or edit anyone directly, any time you want."],
+        "linkLabel": "View your map"
+      },
+      "filter": {
+        "title": "Insight timeline",
+        "intro": "A running summary of your core values, behavior patterns, and insights the Coach has picked up on over time.",
+        "steps": ["Notice what keeps repeating — the next decision is always yours.", "Core values update the moment you change them."],
+        "linkLabel": "View about you"
+      },
+      "principlesTitle": "Four Principles of Experience & Transformation",
+      "principles": [
+        { "title": "Action is core", "description": "Every tool points toward a real experience — helping you turn awareness into lived habits, not just theory." },
+        { "title": "Open up your own agency", "description": "Aura Self AI offers open-ended questions so you find your own answers, instead of imposed advice." },
+        { "title": "Continuous growth", "description": "Insights and your relationship map are nurtured, tracked, and upgraded as you grow — never a one-off fix." },
+        { "title": "The map is yours", "description": "Data is only a mirror. You always own the decisions for your own journey." }
+      ]
+    },
+    "bridge": {
+      "heading": "Your bridge from insight to action",
+      "subtitle": "Small shifts that turn understanding into change.",
+      "energy": {
+        "title": "Today's energy",
+        "body": "Last logged: level {{level}} · {{days}} days ago",
+        "bodyToday": "Last logged: level {{level}} · today",
+        "empty": "No presence logged yet — a light tap to begin",
+        "cta": "Presence history"
+      },
+      "protocols": {
+        "title": "Your protocols",
+        "body": "{{count}} protocols ready to accompany you",
+        "empty": "No protocol yet — set up your first",
+        "cta": "View protocols"
+      },
+      "dashboard": {
+        "title": "The bigger picture",
+        "body": "See your last-7-day rhythm",
+        "cta": "View dashboard"
+      }
+    }
+  },
   "breadcrumb": {
     "home": "Home",
-    "innerverse": "The Innerverse",
-    "outerverse": "The Outerverse",
-    "safeSpace": "Safe Space",
-    "journal": "Journal",
-    "profile": "Profile"
+    "reflection": "Reflection",
+    "emotion": "Emotion",
+    "journal": "Reflectly",
+    "profile": "Profile",
+    "method": "Method",
+    "coach": "Coach",
+    "dashboard": "Insights"
   },
   "mobileFooter": {
+    "coach": "Coach",
+    "dashboard": "Insights",
+    "garden": "Home",
+    "journal": "Reflectly",
+    "emotion": "Emotion",
     "energy": "Energy",
+    "profile": "Me",
     "authDialog": {
       "title": "Login Required",
       "message": "You need to log in to create or view your entries.",
       "confirm": "Log In",
       "cancel": "Later"
-    }
-  },
-  "nav": {
-    "energy": "Energy",
-    "dashboard": "Dashboard",
-    "protocols": "Protocols",
-    "journal": "Journal",
-    "groupSpaces": "Spaces",
-    "groupJourney": "Your journey"
-  },
-  "garden": {
-    "bridge": {
-      "heading": "Your bridge to action",
-      "subtitle": "Three small steps to turn insight into action.",
-      "energy": {
-        "title": "Today's energy",
-        "body": "Last logged: level {{level}} · {{days}} days ago",
-        "bodyToday": "Last logged: level {{level}} · today",
-        "empty": "No entries yet — start with one tap",
-        "cta": "View history"
-      },
-      "protocols": {
-        "title": "Your protocols",
-        "body": "{{count}} protocols ready when you need them",
-        "empty": "No protocol yet — create your first",
-        "cta": "View protocols"
-      },
-      "dashboard": {
-        "title": "Look back at your journey",
-        "body": "See your last-7-day trend",
-        "cta": "View dashboard"
-      }
     }
   },
   "energyLog": {
@@ -100,24 +239,83 @@
       "average": "Average level",
       "totalLogs": "Total logs",
       "bestContext": "Highest energy context"
+    },
+    "you": "You",
+    "pageTitle": "Insights",
+    "pageSubtitle": "Everything the Coach has learned about you — core values, the people who matter, and the insights gathered so far.",
+    "mapTitle": "Relationship Map",
+    "mapSubtitle": "Built up gradually from what you share with the Coach.",
+    "mapEmpty": "No one on the map yet — tell the Coach about the people who matter to you.",
+    "talkToCoach": "Talk to the Coach",
+    "noNudge": "This relationship looks stable.",
+    "loading": "Loading...",
+    "loadMore": "Load more",
+    "insightsTitle": "Insight Timeline",
+    "insightsEmpty": "No insights yet — talk to the Coach to get started.",
+    "category": {
+      "value": "Value",
+      "behaviorPattern": "Behavior pattern",
+      "relationship": "Relationship"
+    },
+    "person": {
+      "add": "+ Add person",
+      "edit": "Edit",
+      "save": "Save",
+      "cancel": "Cancel",
+      "nameRequired": "Enter a name first.",
+      "saveError": "Something went wrong, please try again.",
+      "notesPlaceholder": "Notes (optional)"
     }
   },
   "profilePage": {
+    "title": "My Profile",
     "loginRequired": "Please log in to view your profile.",
     "stats": {
       "dayStreak": "Day Streak",
       "topMood": "Top Mood"
+    },
+    "coreValues": {
+      "title": "Core Values",
+      "edit": "Edit",
+      "add": "+ Set up",
+      "save": "Save",
+      "cancel": "Cancel",
+      "empty": "Not set up yet — the Coach will understand you better once you share what matters to you.",
+      "saveError": "Could not save your core values."
     },
     "emotionOverview": {
       "title": "Emotion Overview",
       "subtitle": "{{entries}} entries, {{emotions}} emotions tagged",
       "empty": "Start journaling to see your emotion patterns."
     },
+    "editName": {
+      "label": "Display Name",
+      "edit": "Edit",
+      "emptyError": "Name cannot be empty.",
+      "updateError": "Failed to update name."
+    },
+    "changePassword": {
+      "label": "Change Password",
+      "change": "Change",
+      "cancel": "Cancel",
+      "currentPlaceholder": "Current password",
+      "newPlaceholder": "New password",
+      "confirmPlaceholder": "Confirm new password",
+      "save": "Save Password",
+      "saving": "Saving...",
+      "fillAllFields": "Please fill in all fields.",
+      "mismatch": "New passwords do not match.",
+      "tooShort": "New password must be at least 6 characters.",
+      "success": "Password changed successfully.",
+      "error": "Failed to change password."
+    },
+    "avatarError": "Failed to upload avatar. Please try again.",
     "settings": {
       "title": "Settings",
       "language": "Language",
       "notifications": "Notifications",
-      "exportData": "Export Data"
+      "exportData": "Export Data",
+      "soon": "Soon"
     },
     "logout": "Log Out",
     "logoutDialog": {
@@ -187,33 +385,33 @@
     }
   },
   "entriesPage": {
-    "title": "Journal",
-    "subtitle": "Every entry is a step toward understanding yourself.",
+    "title": "Reflectly",
+    "subtitle": "Every reflection is a step toward understanding yourself.",
     "loadMore": "Load More",
     "showing": "Showing {{current}} of {{total}} entries",
-    "emptyState": "The courage to begin is the courage to grow.",
-    "emptyStateHint": "Start your first journal entry and take the first step.",
+    "emptyState": "No reflections yet",
+    "emptyStateHint": "Jot down what's on your mind right now — it only takes a minute.",
+    "startWriting": "Start writing",
     "loginRequired": "Log in to begin your journey of self-understanding.",
-    "loginRequiredHint": "Your journal is private, encrypted, and waiting for you.",
-    "laoTzuQuote": "A journey of a thousand miles begins with a single step — yours starts right here.",
-    "searchPlaceholder": "Search entries...",
+    "loginRequiredHint": "Your reflections are private, encrypted, and waiting for you.",
+    "searchPlaceholder": "Search reflections...",
     "filterAll": "All",
     "filterToday": "Today",
     "filterWeek": "This Week",
     "filterMonth": "This Month",
     "filterYear": "This Year",
-    "noResults": "No entries match your search.",
-    "edit": "Edit Entry",
-    "deleteConfirmTitle": "Delete Entry",
-    "deleteConfirmMessage": "Are you sure you want to delete this entry?",
+    "noResults": "No reflections match your search.",
+    "edit": "Edit Reflection",
+    "deleteConfirmTitle": "Delete Reflection",
+    "deleteConfirmMessage": "Are you sure you want to delete this reflection?",
     "deleteConfirmBtn": "Delete",
     "deleteCancel": "Cancel",
-    "editTitle": "Edit Entry",
+    "editTitle": "Edit Reflection",
     "editSubtitle": "Revisit and refine your reflection.",
-    "updateSuccess": "Your entry has been updated.",
-    "updateError": "Failed to update entry.",
-    "deleteSuccess": "Entry deleted.",
-    "deleteError": "Failed to delete entry."
+    "updateSuccess": "Your reflection has been updated.",
+    "updateError": "Failed to update reflection.",
+    "deleteSuccess": "Reflection deleted.",
+    "deleteError": "Failed to delete reflection."
   },
   "actionProtocol": {
     "list": {
@@ -266,43 +464,14 @@
       "DIDNT_WORK": "It didn't work"
     }
   },
-  "garden": {
-    "framework": {
-      "goOut": {
-        "title": "How I go out",
-        "intro": "Before stepping into the outside world, I pause to check my energy and emotions — this is Layer 1 Innerverse.",
-        "steps": ["Log your current energy level (1-10) before you start", "Tag the emotion you're feeling, without judging it right or wrong", "Notice patterns — which activities lift your energy, which drain it", "Choose how to engage based on your actual state right now"],
-        "linkLabel": "View your energy"
-      },
-      "comeBack": {
-        "title": "How I come back",
-        "intro": "When a hard moment hits, I use an Action Protocol — MimoSe's core differentiator — instead of reacting on the spot.",
-        "steps": ["Write the protocol in advance, while your mind is calm", "Use the protocol you prepared as soon as the situation happens", "Mark it as used and record the outcome", "Track its effectiveness over time and adjust if needed"],
-        "linkLabel": "View your protocols"
-      },
-      "filter": {
-        "title": "How I look back",
-        "intro": "The Dashboard and trend charts (Layer 5 Insight & Growth) show me patterns over time — so I can recognize them myself, not have the app conclude for me.",
-        "steps": ["Review your energy trend chart by day and by week", "Compare energy levels across different activities", "Notice the moments when your energy tends to run lowest", "Draw your own conclusions about what's repeating — the next decision is yours"],
-        "linkLabel": "View your dashboard"
-      },
-      "principlesTitle": "Four operating principles",
-      "principles": [
-        { "title": "Accompany, don't theorize", "description": "Every feature ties to a concrete action — not reading material." },
-        { "title": "Self-resolve", "description": "Tools offer question frameworks; the app never gives advice on your behalf." },
-        { "title": "Protocols have a lifecycle", "description": "Action Protocols are tracked and revisited over time, not used once and forgotten." },
-        { "title": "Convenience at the right moment", "description": "1-2 tap interactions are favored, especially in stressful moments." }
-      ]
-    }
-  },
   "phuongPhapPage": {
     "hero": {
       "badge": "Self-leadership foundations",
-      "title": "Why MimoSe <span class=\"highlight\">works this way</span>",
-      "subtitle": "MimoSe is built on Leading Self: understanding and guiding yourself comes before guiding anyone else. This page explains the reasoning behind the features you use every day."
+      "title": "Why Aura Self AI <span class=\"highlight\">works this way</span>",
+      "subtitle": "Aura Self AI is built on Leading Self: understanding and guiding yourself comes before guiding anyone else. This page explains the reasoning behind the features you use every day."
     },
     "layers": {
-      "title": "The four layers MimoSe has today",
+      "title": "The four layers Aura Self AI has today",
       "subtitle": "Every feature you use belongs to one layer of the self-leadership model.",
       "items": {
         "foundation": {
@@ -327,6 +496,58 @@
       "title": "Ready to apply it?",
       "subtitle": "Start with your first entry — a journal line, an energy log, or a protocol.",
       "button": "Start your first entry"
+    }
+  },
+  "zonePage": {
+    "comingSoon": "Coming soon",
+    "comingSoonDesc": "This feature is still being built. Please check back later.",
+    "writeJournal": "Write a reflection",
+    "viewJournal": "View reflections",
+    "backToGarden": "Back to Home"
+  },
+  "emotionPage": {
+    "title": "Emotion Profile",
+    "subtitle": "Recognize and track your emotion patterns — the first step to understanding yourself.",
+    "empty": "Start journaling to see your emotion patterns take shape."
+  },
+  "notFound": {
+    "title": "Page not found",
+    "subtitle": "This link may be outdated or no longer exists.",
+    "back": "Back to Home"
+  },
+  "auth": {
+    "loginTitle": "Log In",
+    "signupTitle": "Create Account",
+    "fullName": "Full Name",
+    "username": "Username",
+    "password": "Password",
+    "confirmPassword": "Confirm Password",
+    "loginButton": "Log In",
+    "signupButton": "Sign Up",
+    "googleLogin": "Continue with Google",
+    "noAccount": "Don't have an account?",
+    "hasAccount": "Already have an account?",
+    "signupLink": "Sign up",
+    "loginLink": "Sign in",
+    "fullNamePlaceholder": "Your full name",
+    "usernamePlaceholder": "Enter your username",
+    "usernameChoosePlaceholder": "Choose a username",
+    "forgotPassword": "Forgot?",
+    "or": "or",
+    "signingIn": "Signing in...",
+    "creatingAccount": "Creating account...",
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service",
+    "errors": {
+      "fillAllFields": "Please fill in all fields.",
+      "usernamePasswordRequired": "Please enter both username and password.",
+      "loginFailed": "Login failed. Please check your credentials.",
+      "googleCodeMissing": "Did not receive authorization code from Google.",
+      "googleFailed": "Google authentication failed. Please try again.",
+      "networkError": "Network error: login failed during backend authentication.",
+      "passwordMismatch": "Passwords do not match.",
+      "passwordTooShort": "Password must be at least 6 characters.",
+      "signupFailed": "Signup failed. Please try again."
     }
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -50,24 +50,26 @@
     "sendError": "Không thể gửi tin nhắn lúc này. Vui lòng thử lại."
   },
   "brand": {
-    "name": "MimoSe",
-    "acronym": "Make Sense Of ME",
-    "slogan": "Lắng nghe & Lãnh đạo chính mình",
-    "description": "Khu vườn tâm trí — nơi bạn dừng lại để lắng nghe cảm xúc, gọi tên suy nghĩ và thấu hiểu nhu cầu, trước khi chủ động ứng phó với thế giới.",
-    "tagline": "Sự hiện diện cùng bản thân, mỗi ngày.",
-    "footer": "© 2026 MimoSe — Make Sense Of ME. Đồng hành cùng hành trình Thấu hiểu & Lãnh đạo Bản thân.",
-    "welcome": "Chào mừng bạn quay về với khu vườn tâm trí."
+    "name": "Aura Self AI",
+    "acronym": "AI Coach Thấu Hiểu Bản Thân",
+    "slogan": "Hiểu mình rõ hơn, qua từng cuộc trò chuyện",
+    "description": "Aura Self AI là AI Coach trò chuyện cùng bạn, tự động dựng nên bản đồ mối quan hệ và những insight về chính bạn — không phán xét, không áp đặt lời khuyên.",
+    "tagline": "Trò chuyện để thấu hiểu chính mình, mỗi ngày.",
+    "footer": "© 2026 Aura Self AI. Đồng hành cùng hành trình Thấu hiểu & Lãnh đạo Bản thân.",
+    "welcome": "Chào mừng bạn quay lại với Aura Self AI.",
+    "ctaLoggedOut": "Bắt đầu trò chuyện với Coach",
+    "ctaLoggedIn": "Tiếp tục trò chuyện"
   },
   "nav": {
     "coach": "Coach",
-    "garden": "Khu vườn",
+    "garden": "Trang chủ",
     "reflection": "Tự chiêm nghiệm",
     "emotion": "Cảm xúc",
     "energy": "Năng lượng",
-    "dashboard": "Về bạn",
+    "dashboard": "Thấu hiểu",
     "protocols": "Kịch bản",
     "method": "Phương pháp",
-    "journal": "Nhật ký",
+    "journal": "Đúc kết",
     "profile": "Tôi",
     "login": "Đăng nhập",
     "startJourney": "Bắt đầu hành trình",
@@ -112,28 +114,28 @@
     },
     "framework": {
       "goOut": {
-        "title": "Tôi hướng ra thế giới như thế nào?",
-        "intro": "Trước khi kết nối với thế giới bên ngoài, tôi dừng lại một nhịp để cảm nhận năng lượng và cảm xúc của chính mình — làm chủ Thế giới Nội tâm (Innerverse).",
-        "steps": ["Lắng nghe & định vị mức năng lượng hiện tại (1-10) trước khi bắt đầu.", "Gọi tên cảm xúc đang hiện diện với sự thấu hiểu, không phán xét.", "Nhận diện chu kỳ — phân định rõ hoạt động nào tái tạo hay làm hao tổn năng lượng.", "Chủ động lựa chọn cách tham gia phù hợp với trạng thái thật lúc này."],
-        "linkLabel": "Khám phá mức năng lượng của bạn"
+        "title": "Trò chuyện cùng AI Coach",
+        "intro": "Một không gian trò chuyện kiểu Socratic — Coach đặt câu hỏi gợi mở để bạn tự tìm ra câu trả lời của chính mình.",
+        "steps": ["Chia sẻ điều đang ở trong đầu bạn, không cần chuẩn bị trước.", "Coach tự ghi nhớ điều quan trọng với bạn qua từng cuộc trò chuyện."],
+        "linkLabel": "Bắt đầu trò chuyện"
       },
       "comeBack": {
-        "title": "Tôi quay về phục hồi như thế nào?",
-        "intro": "Khi đối mặt với thử thách, tôi kích hoạt Kịch bản Ứng phó (Action Protocol) đã chuẩn bị sẵn — lựa chọn làm chủ cách đáp lại thay vì phản ứng bản năng.",
-        "steps": ["Thiết lập trước kịch bản ứng phó khi tâm trí đang ở trạng thái bình tĩnh và sáng suốt.", "Kích hoạt đúng kịch bản đã chuẩn bị ngay khi tình huống phát sinh.", "Ghi nhận trải nghiệm và quan sát kết quả thực tế.", "Theo dõi và điều chỉnh kịch bản theo thời gian để ngày càng linh hoạt hơn."],
-        "linkLabel": "Danh sách kịch bản ứng phó của bạn"
+        "title": "Bản đồ mối quan hệ của bạn",
+        "intro": "Tự động dựng nên từ những gì bạn chia sẻ — giúp bạn nhìn rõ ai đang nuôi dưỡng và ai đang khiến bạn cạn kiệt.",
+        "steps": ["Không cần nhập liệu thủ công — Coach tự nhận diện qua trò chuyện.", "Thêm hoặc chỉnh sửa trực tiếp bất cứ lúc nào bạn muốn."],
+        "linkLabel": "Xem bản đồ của bạn"
       },
       "filter": {
-        "title": "Tôi quan sát & soi chiếu như thế nào?",
-        "intro": "Bảng thông tin và bức tranh tổng thể cho tôi quan sát các chu kỳ nhận thức — để chính tôi tự thấu hiểu, không cần hệ thống kết luận thay.",
-        "steps": ["Quan sát sự biến động năng lượng theo chu kỳ ngày và tuần.", "So sánh mức độ tiêu hao hay tái tạo năng lượng qua từng trải nghiệm.", "Lắng nghe khoảng lặng — nhận diện thời điểm năng lượng thường xuống thấp.", "Tự đúc kết các chu kỳ hành vi — nắm giữ trọn vẹn quyền lựa chọn cho tương lai."],
-        "linkLabel": "Xem bảng thông tin soi chiếu"
+        "title": "Dòng thời gian Insight",
+        "intro": "Tổng hợp giá trị cốt lõi, mẫu hành vi và insight Coach đã đúc kết được về bạn theo thời gian.",
+        "steps": ["Tự nhận ra điều đang lặp lại — quyết định tiếp theo luôn là của bạn.", "Giá trị cốt lõi được cập nhật ngay khi bạn thay đổi."],
+        "linkLabel": "Xem về bạn"
       },
       "principlesTitle": "Bốn Nguyên tắc Trải nghiệm & Chuyển hóa",
       "principles": [
         { "title": "Hành động là cốt lõi", "description": "Mỗi công cụ đều hướng tới một trải nghiệm thực tế — giúp bạn chuyển hóa nhận thức thành thói quen sống, không dừng ở lý thuyết." },
-        { "title": "Khơi mở Tính chủ thể", "description": "MimoSe trao khung câu hỏi gợi mở để bạn tự tìm ra câu trả lời của chính mình, thay vì đưa ra lời khuyên áp đặt." },
-        { "title": "Phát triển liên tục", "description": "Kịch bản ứng phó được nuôi dưỡng, theo dõi và nâng cấp theo sự trưởng thành của bạn, không phải giải pháp tạm thời." },
+        { "title": "Khơi mở Tính chủ thể", "description": "Aura Self AI trao khung câu hỏi gợi mở để bạn tự tìm ra câu trả lời của chính mình, thay vì đưa ra lời khuyên áp đặt." },
+        { "title": "Phát triển liên tục", "description": "Insight và bản đồ mối quan hệ được nuôi dưỡng, theo dõi và nâng cấp theo sự trưởng thành của bạn, không phải giải pháp tạm thời." },
         { "title": "Bản đồ là của bạn", "description": "Dữ liệu chỉ là gương soi. Bạn luôn là người làm chủ và đưa ra quyết định cho hành trình của chính mình." }
       ]
     },
@@ -161,18 +163,20 @@
     }
   },
   "breadcrumb": {
-    "home": "Khu vườn",
+    "home": "Trang chủ",
     "reflection": "Tự chiêm nghiệm",
     "emotion": "Cảm xúc",
-    "journal": "Nhật ký",
+    "journal": "Đúc kết",
     "profile": "Hồ sơ",
-    "method": "Phương pháp"
+    "method": "Phương pháp",
+    "coach": "Coach",
+    "dashboard": "Thấu hiểu"
   },
   "mobileFooter": {
     "coach": "Coach",
-    "dashboard": "Về bạn",
-    "garden": "Vườn",
-    "journal": "Nhật ký",
+    "dashboard": "Thấu hiểu",
+    "garden": "Trang chủ",
+    "journal": "Đúc kết",
     "emotion": "Cảm xúc",
     "energy": "Năng lượng",
     "profile": "Tôi",
@@ -237,7 +241,7 @@
       "bestContext": "Hoạt động năng lượng cao nhất"
     },
     "you": "Bạn",
-    "pageTitle": "Về bạn",
+    "pageTitle": "Thấu hiểu",
     "pageSubtitle": "Mọi thứ Coach đã hiểu về bạn — giá trị cốt lõi, những người quan trọng, và những insight đã đúc kết được.",
     "mapTitle": "Bản đồ mối quan hệ",
     "mapSubtitle": "Được xây dựng dần từ những gì bạn chia sẻ với Coach.",
@@ -257,14 +261,15 @@
       "add": "+ Thêm người",
       "edit": "Chỉnh sửa",
       "save": "Lưu",
+      "cancel": "Hủy",
       "nameRequired": "Nhập tên trước đã.",
       "saveError": "Có lỗi xảy ra, vui lòng thử lại.",
       "notesPlaceholder": "Ghi chú (tuỳ chọn)"
     }
   },
   "profilePage": {
-    "title": "Khu vườn của tôi",
-    "loginRequired": "Vui lòng đăng nhập để xem khu vườn của bạn.",
+    "title": "Hồ sơ của tôi",
+    "loginRequired": "Vui lòng đăng nhập để xem hồ sơ của bạn.",
     "stats": {
       "dayStreak": "Chuỗi ngày",
       "topMood": "Cảm xúc chính"
@@ -274,18 +279,43 @@
       "edit": "Chỉnh sửa",
       "add": "+ Thiết lập",
       "save": "Lưu",
-      "empty": "Chưa thiết lập — Coach sẽ hiểu bạn hơn nếu bạn cho biết điều gì quan trọng với mình."
+      "cancel": "Hủy",
+      "empty": "Chưa thiết lập — Coach sẽ hiểu bạn hơn nếu bạn cho biết điều gì quan trọng với mình.",
+      "saveError": "Lưu giá trị cốt lõi thất bại."
     },
     "emotionOverview": {
       "title": "Tổng quan Cảm xúc",
       "subtitle": "{{entries}} bài viết, {{emotions}} cảm xúc được gắn",
-      "empty": "Bắt đầu viết nhật ký để xem mẫu hình cảm xúc của bạn."
+      "empty": "Bắt đầu viết đúc kết để xem mẫu hình cảm xúc của bạn."
     },
+    "editName": {
+      "label": "Tên hiển thị",
+      "edit": "Chỉnh sửa",
+      "emptyError": "Tên không được để trống.",
+      "updateError": "Cập nhật tên thất bại."
+    },
+    "changePassword": {
+      "label": "Đổi mật khẩu",
+      "change": "Đổi",
+      "cancel": "Hủy",
+      "currentPlaceholder": "Mật khẩu hiện tại",
+      "newPlaceholder": "Mật khẩu mới",
+      "confirmPlaceholder": "Xác nhận mật khẩu mới",
+      "save": "Lưu mật khẩu",
+      "saving": "Đang lưu...",
+      "fillAllFields": "Vui lòng điền đầy đủ các trường.",
+      "mismatch": "Mật khẩu mới không khớp.",
+      "tooShort": "Mật khẩu mới phải có ít nhất 6 ký tự.",
+      "success": "Đổi mật khẩu thành công.",
+      "error": "Đổi mật khẩu thất bại."
+    },
+    "avatarError": "Tải ảnh đại diện thất bại. Vui lòng thử lại.",
     "settings": {
       "title": "Cài đặt",
       "language": "Ngôn ngữ",
       "notifications": "Thông báo",
-      "exportData": "Xuất dữ liệu"
+      "exportData": "Xuất dữ liệu",
+      "soon": "Sắp có"
     },
     "logout": "Đăng xuất",
     "logoutDialog": {
@@ -355,33 +385,33 @@
     }
   },
   "entriesPage": {
-    "title": "Nhật ký tự chiêm nghiệm",
-    "subtitle": "Mỗi dòng nhật ký là một bước để làm rõ chính mình.",
+    "title": "Đúc kết",
+    "subtitle": "Mỗi đúc kết là một bước để làm rõ chính mình.",
     "loadMore": "Tải thêm",
     "showing": "Hiển thị {{current}} trong {{total}} bài viết",
-    "emptyState": "Can đảm để bắt đầu là can đảm để trưởng thành.",
-    "emptyStateHint": "Viết bài nhật ký đầu tiên và bước đi bước đầu tiên.",
+    "emptyState": "Chưa có đúc kết nào",
+    "emptyStateHint": "Ghi lại điều bạn đang nghĩ ngay bây giờ — chỉ mất một phút.",
+    "startWriting": "Bắt đầu viết",
     "loginRequired": "Đăng nhập để bắt đầu hành trình tự hiểu bản thân.",
-    "loginRequiredHint": "Nhật ký của bạn riêng tư, mã hóa và đang chờ bạn.",
-    "laoTzuQuote": "Hành trình vạn dặm bắt đầu từ một bước chân — bước đi của bạn bắt đầu ngay tại đây.",
-    "searchPlaceholder": "Tìm kiếm nhật ký...",
+    "loginRequiredHint": "Đúc kết của bạn riêng tư, mã hóa và đang chờ bạn.",
+    "searchPlaceholder": "Tìm kiếm đúc kết...",
     "filterAll": "Tất cả",
     "filterToday": "Hôm nay",
     "filterWeek": "Tuần này",
     "filterMonth": "Tháng này",
     "filterYear": "Năm nay",
-    "noResults": "Không tìm thấy nhật ký phù hợp.",
-    "edit": "Chỉnh sửa nhật ký",
-    "deleteConfirmTitle": "Xóa nhật ký",
-    "deleteConfirmMessage": "Bạn có chắc chắn muốn xóa nhật ký này?",
+    "noResults": "Không tìm thấy đúc kết phù hợp.",
+    "edit": "Chỉnh sửa đúc kết",
+    "deleteConfirmTitle": "Xóa đúc kết",
+    "deleteConfirmMessage": "Bạn có chắc chắn muốn xóa đúc kết này?",
     "deleteConfirmBtn": "Xóa",
     "deleteCancel": "Hủy",
-    "editTitle": "Chỉnh sửa nhật ký",
+    "editTitle": "Chỉnh sửa đúc kết",
     "editSubtitle": "Xem lại và hoàn thiện suy ngẫm của bạn.",
-    "updateSuccess": "Nhật ký đã được cập nhật.",
-    "updateError": "Không thể cập nhật nhật ký.",
-    "deleteSuccess": "Đã xóa nhật ký.",
-    "deleteError": "Không thể xóa nhật ký."
+    "updateSuccess": "Đúc kết đã được cập nhật.",
+    "updateError": "Không thể cập nhật đúc kết.",
+    "deleteSuccess": "Đã xóa đúc kết.",
+    "deleteError": "Không thể xóa đúc kết."
   },
   "actionProtocol": {
     "list": {
@@ -437,16 +467,16 @@
   "phuongPhapPage": {
     "hero": {
       "badge": "Cơ sở khoa học lãnh đạo bản thân",
-      "title": "Vì sao MimoSe <span class=\"highlight\">vận hành như vậy</span>",
-      "subtitle": "MimoSe được xây dựng theo nguyên lý Leading Self: bạn cần hiểu và dẫn dắt chính mình trước khi dẫn dắt người khác. Trang này giải thích cơ sở đằng sau từng tính năng bạn đang dùng."
+      "title": "Vì sao Aura Self AI <span class=\"highlight\">vận hành như vậy</span>",
+      "subtitle": "Aura Self AI được xây dựng theo nguyên lý Leading Self: bạn cần hiểu và dẫn dắt chính mình trước khi dẫn dắt người khác. Trang này giải thích cơ sở đằng sau từng tính năng bạn đang dùng."
     },
     "layers": {
-      "title": "Bốn lớp MimoSe đã có",
+      "title": "Bốn lớp Aura Self AI đã có",
       "subtitle": "Mỗi tính năng bạn dùng đều thuộc một lớp trong mô hình lãnh đạo bản thân.",
       "items": {
         "foundation": {
           "label": "Lớp 0 · Nền tảng",
-          "description": "Tài khoản, hồ sơ và nhật ký — nơi mọi dữ liệu của bạn bắt đầu."
+          "description": "Tài khoản, hồ sơ và đúc kết — nơi mọi dữ liệu của bạn bắt đầu."
         },
         "innerverse": {
           "label": "Lớp 1 · Nội tâm (Innerverse)",
@@ -464,30 +494,31 @@
     },
     "cta": {
       "title": "Sẵn sàng áp dụng?",
-      "subtitle": "Bắt đầu bằng ghi nhận đầu tiên của bạn — một dòng nhật ký, một mức năng lượng, hay một kịch bản ứng phó.",
+      "subtitle": "Bắt đầu bằng ghi nhận đầu tiên của bạn — một dòng đúc kết, một mức năng lượng, hay một kịch bản ứng phó.",
       "button": "Bắt đầu ghi nhận"
     }
   },
   "zonePage": {
     "comingSoon": "Sắp mở",
-    "comingSoonDesc": "Vùng này đang được chăm sóc. Hãy quay lại sau.",
-    "writeJournal": "Viết nhật ký",
-    "viewJournal": "Xem nhật ký",
-    "backToGarden": "Về khu vườn"
+    "comingSoonDesc": "Tính năng này đang được xây dựng. Hãy quay lại sau.",
+    "writeJournal": "Viết đúc kết",
+    "viewJournal": "Xem đúc kết",
+    "backToGarden": "Về trang chủ"
   },
   "emotionPage": {
-    "title": "Hồ sen cảm xúc",
+    "title": "Hồ sơ cảm xúc",
     "subtitle": "Nhận diện và theo dõi mẫu hình cảm xúc — bước đầu tiên để hiểu mình.",
-    "empty": "Bắt đầu viết nhật ký để thấy mẫu hình cảm xúc của bạn nở rộ trong vườn."
+    "empty": "Bắt đầu viết đúc kết để thấy mẫu hình cảm xúc của bạn hiện rõ hơn."
   },
   "notFound": {
-    "title": "Bạn đã đi lạc khỏi vườn",
-    "subtitle": "Trang này không tồn tại trong khu vườn tâm trí.",
-    "back": "Về khu vườn"
+    "title": "Trang bạn tìm không tồn tại",
+    "subtitle": "Có thể đường dẫn đã thay đổi hoặc không còn tồn tại.",
+    "back": "Về trang chủ"
   },
   "auth": {
     "loginTitle": "Đăng nhập",
     "signupTitle": "Tạo tài khoản",
+    "fullName": "Họ và tên",
     "username": "Tên đăng nhập",
     "password": "Mật khẩu",
     "confirmPassword": "Xác nhận mật khẩu",
@@ -497,6 +528,26 @@
     "noAccount": "Chưa có tài khoản?",
     "hasAccount": "Đã có tài khoản?",
     "signupLink": "Đăng ký",
-    "loginLink": "Đăng nhập"
+    "loginLink": "Đăng nhập",
+    "fullNamePlaceholder": "Họ và tên của bạn",
+    "usernamePlaceholder": "Nhập tên đăng nhập",
+    "usernameChoosePlaceholder": "Chọn tên đăng nhập",
+    "forgotPassword": "Quên mật khẩu?",
+    "or": "hoặc",
+    "signingIn": "Đang đăng nhập...",
+    "creatingAccount": "Đang tạo tài khoản...",
+    "privacyPolicy": "Chính sách bảo mật",
+    "termsOfService": "Điều khoản dịch vụ",
+    "errors": {
+      "fillAllFields": "Vui lòng điền đầy đủ thông tin.",
+      "usernamePasswordRequired": "Vui lòng nhập tên đăng nhập và mật khẩu.",
+      "loginFailed": "Đăng nhập thất bại. Vui lòng kiểm tra lại thông tin.",
+      "googleCodeMissing": "Không nhận được mã xác thực từ Google.",
+      "googleFailed": "Xác thực Google thất bại. Vui lòng thử lại.",
+      "networkError": "Lỗi mạng: đăng nhập thất bại ở bước xác thực.",
+      "passwordMismatch": "Mật khẩu không khớp.",
+      "passwordTooShort": "Mật khẩu phải có ít nhất 6 ký tự.",
+      "signupFailed": "Đăng ký thất bại. Vui lòng thử lại."
+    }
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -31,14 +31,19 @@ a.text-primary,
   color: var(--c-danger) !important;
 }
 
-a {
-  font-weight: 500;
-  color: var(--c-primary);
-  text-decoration: inherit;
-}
+// Wrapped in Tailwind's `base` layer for the same reason as the button/heading rules below —
+// otherwise this un-layered `a { color }` always beats a Tailwind utility like `text-white`
+// on an <a> styled as a button (e.g. ButtonLink), regardless of specificity or source order.
+@layer base {
+  a {
+    font-weight: 500;
+    color: var(--c-primary);
+    text-decoration: inherit;
+  }
 
-a:hover {
-  color: var(--c-secondary);
+  a:hover {
+    color: var(--c-secondary);
+  }
 }
 
 // Global Reset and Base Styles
@@ -68,31 +73,37 @@ body {
 }
 
 // Typography - Responsive
-h1 {
-  line-height: var(--line-height-tight);
-  font-weight: var(--font-weight-bold);
-  margin: 0 0 var(--spacing-lg) 0;
-  @include font-responsive(var(--font-size-2xl), var(--font-size-3xl), 3.2em);
-}
+// Wrapped in Tailwind's `base` layer for the same reason as the button rule below —
+// otherwise this un-layered CSS always beats Tailwind utilities like text-2xl/font-bold
+// on <h1>/<h2>/<h3>/<p> regardless of specificity or source order (confirmed live: a
+// Tailwind `text-2xl` heading was silently rendering at this rule's 3.2em instead).
+@layer base {
+  h1 {
+    line-height: var(--line-height-tight);
+    font-weight: var(--font-weight-bold);
+    margin: 0 0 var(--spacing-lg) 0;
+    @include font-responsive(var(--font-size-2xl), var(--font-size-3xl), 3.2em);
+  }
 
-h2 {
-  line-height: var(--line-height-tight);
-  font-weight: var(--font-weight-semibold);
-  margin: 0 0 var(--spacing-md) 0;
-  @include font-responsive(var(--font-size-xl), var(--font-size-2xl), 2.4em);
-}
+  h2 {
+    line-height: var(--line-height-tight);
+    font-weight: var(--font-weight-semibold);
+    margin: 0 0 var(--spacing-md) 0;
+    @include font-responsive(var(--font-size-xl), var(--font-size-2xl), 2.4em);
+  }
 
-h3 {
-  line-height: var(--line-height-normal);
-  font-weight: var(--font-weight-semibold);
-  margin: 0 0 var(--spacing-sm) 0;
-  @include font-responsive(var(--font-size-lg), var(--font-size-xl), 1.8em);
-}
+  h3 {
+    line-height: var(--line-height-normal);
+    font-weight: var(--font-weight-semibold);
+    margin: 0 0 var(--spacing-sm) 0;
+    @include font-responsive(var(--font-size-lg), var(--font-size-xl), 1.8em);
+  }
 
-p {
-  line-height: var(--line-height-relaxed);
-  margin: 0 0 var(--spacing-md) 0;
-  @include font-responsive(var(--font-size-sm), var(--font-size-base), var(--font-size-base));
+  p {
+    line-height: var(--line-height-relaxed);
+    margin: 0 0 var(--spacing-md) 0;
+    @include font-responsive(var(--font-size-sm), var(--font-size-base), var(--font-size-base));
+  }
 }
 
 // Button - Responsive

--- a/src/layouts/MimoHeader/MimoHeader.tsx
+++ b/src/layouts/MimoHeader/MimoHeader.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { LuLogOut, LuMenu, LuUser, LuX } from 'react-icons/lu';
+import { LuLogOut, LuMenu, LuX } from 'react-icons/lu';
 import { APP_ROUTES } from '../../constants/route';
 import { useAuth } from '../../providers/AuthProvider';
 import LanguageSwitcher from '../../components/LanguageSwitcher/LanguageSwitcher';
+import { Button } from '../../components/Button/Button';
 import './MimoHeader.scss';
 
 interface MimoHeaderProps {
@@ -66,6 +67,13 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
         <div className="mimo-header__nav">
           <div className="mimo-header__nav-links">
             <a
+              onClick={() => navigate(APP_ROUTES.WELCOME)}
+              className={isActive(APP_ROUTES.WELCOME) ? 'active' : ''}
+              style={{ cursor: 'pointer' }}
+            >
+              {t('nav.garden')}
+            </a>
+            <a
               onClick={() => navigate(APP_ROUTES.COACH_CHAT)}
               className={isActive(APP_ROUTES.COACH_CHAT) ? 'active' : ''}
               style={{ cursor: 'pointer' }}
@@ -86,6 +94,15 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
             >
               {t('nav.journal')}
             </a>
+            {currentUser && (
+              <a
+                onClick={() => navigate(APP_ROUTES.PROFILE)}
+                className={isActive(APP_ROUTES.PROFILE) ? 'active' : ''}
+                style={{ cursor: 'pointer' }}
+              >
+                {t('nav.profile')}
+              </a>
+            )}
           </div>
 
           {currentUser ? (
@@ -98,7 +115,7 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
                 {currentUser.pictureUrl && !avatarError ? (
                   <img
                     src={currentUser.pictureUrl}
-                    alt="User Avatar"
+                    alt={currentUser.fullName}
                     className="avatar-img"
                     onError={() => setAvatarError(true)}
                     referrerPolicy="no-referrer"
@@ -121,10 +138,6 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
                     <LanguageSwitcher />
                   </div>
                   <div className="dropdown-divider" />
-                  <button onClick={handleGoProfile} className="dropdown-item">
-                    <LuUser size={16} /> {t('nav.profile')}
-                  </button>
-                  <div className="dropdown-divider" />
                   <button onClick={handleLogout} className="dropdown-item text-red-500">
                     <LuLogOut size={16} /> {t('profilePage.logout')}
                   </button>
@@ -134,9 +147,9 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
           ) : (
             <div className="mimo-header__auth-section">
               <LanguageSwitcher />
-              <button className="btn-cta" onClick={handleLogin}>
+              <Button variant="primary" size="sm" shape="pill" onClick={handleLogin}>
                 {t('nav.startJourney')}
-              </button>
+              </Button>
             </div>
           )}
         </div>
@@ -148,6 +161,7 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
 
       {isMenuOpen && (
         <div className="mimo-header__mobile-menu">
+          <a onClick={() => navTo(APP_ROUTES.WELCOME)} style={{ cursor: 'pointer' }}>{t('nav.garden')}</a>
           <a onClick={() => navTo(APP_ROUTES.COACH_CHAT)} style={{ cursor: 'pointer' }}>{t('nav.coach')}</a>
           <a onClick={() => navTo(APP_ROUTES.DASHBOARD)} style={{ cursor: 'pointer' }}>{t('nav.dashboard')}</a>
           <a onClick={() => navTo(APP_ROUTES.ENTRIES_LIST)} style={{ cursor: 'pointer' }}>{t('nav.journal')}</a>
@@ -164,7 +178,7 @@ const MimoHeader = ({ scrolled = false }: MimoHeaderProps) => {
                   {currentUser.pictureUrl && !avatarError ? (
                     <img
                       src={currentUser.pictureUrl}
-                      alt="User Avatar"
+                      alt={currentUser.fullName}
                       className="mobile-avatar-img"
                       onError={() => setAvatarError(true)}
                       referrerPolicy="no-referrer"

--- a/src/layouts/MobileFooter/__tests__/MobileFooter.test.tsx
+++ b/src/layouts/MobileFooter/__tests__/MobileFooter.test.tsx
@@ -19,7 +19,7 @@ vi.mock('react-i18next', () => ({
             const labels: Record<string, string> = {
                 'mobileFooter.coach': 'Coach',
                 'mobileFooter.dashboard': 'Bảng thông tin',
-                'mobileFooter.journal': 'Nhật ký',
+                'mobileFooter.journal': 'Đúc kết',
                 'mobileFooter.profile': 'Tôi',
             };
             return labels[key] ?? key;
@@ -59,7 +59,7 @@ describe('MobileFooter', () => {
 
             expect(screen.getByRole('button', { name: 'Coach' })).toBeInTheDocument();
             expect(screen.getByRole('button', { name: 'Bảng thông tin' })).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: 'Nhật ký' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Đúc kết' })).toBeInTheDocument();
             expect(screen.getByRole('button', { name: 'Tôi' })).toBeInTheDocument();
             expect(document.querySelector('.mobile-footer__fab')).toBeInTheDocument();
         });
@@ -79,7 +79,7 @@ describe('MobileFooter', () => {
 
             const activeItems = document.querySelectorAll('.mobile-footer__item--active');
             expect(activeItems.length).toBe(1);
-            expect(activeItems[0].textContent).toContain('Nhật ký');
+            expect(activeItems[0].textContent).toContain('Đúc kết');
         });
 
         it('should mark dashboard as active when on /dashboard', () => {

--- a/src/pages/CoachChatPage/CoachChatPage.tsx
+++ b/src/pages/CoachChatPage/CoachChatPage.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import MessageList from '../../components/Chat/MessageList';
 import MessageInput from '../../components/Chat/MessageInput';
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../components/Button/Button';
 import type { ConversationMessage } from '../../models/conversation';
 import { conversationsService } from '../../services/conversationsService';
 import { useSendMessageMutation, useEndConversationMutation } from '../../queries/conversationsQueryHook';
@@ -68,33 +70,41 @@ const CoachChatPage = () => {
   };
 
   return (
-    <div className="flex h-[calc(100dvh-var(--header-h,64px)-var(--footer-h,64px))] flex-col bg-coach-bg">
-      <div className="flex items-center justify-between border-b border-coach-border bg-coach-surface px-4 py-3">
-        <div>
-          <h1 className="text-base font-semibold text-coach-text">{t('coach.title', 'Coach')}</h1>
-          <p className="text-xs text-coach-text-muted">
-            {t('coach.subtitle', 'Một không gian để bạn tự đào sâu suy nghĩ của mình')}
-          </p>
+    <div className="mx-auto flex h-[calc(100dvh-var(--header-h,64px)-var(--footer-h,64px))] w-full max-w-2xl flex-col border-x border-coach-border bg-coach-bg">
+      <div className="border-b border-coach-border bg-coach-surface px-4 pt-3 pb-4 sm:px-6">
+        <Breadcrumb
+          variant="light"
+          items={[{ label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME }, { label: t('breadcrumb.coach') }]}
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-coach-text [font-family:var(--font-family-heading)]">
+              {t('coach.title')}
+            </h1>
+            <p className="mt-1 text-sm text-coach-text-muted">
+              {t('coach.subtitle')}
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleEndSession}
+            disabled={!conversationId || endConversation.isPending}
+          >
+            {t('coach.endSession')}
+          </Button>
         </div>
-        <button
-          type="button"
-          onClick={handleEndSession}
-          disabled={!conversationId || endConversation.isPending}
-          className="rounded-lg border border-coach-border px-3 py-1.5 text-xs font-medium text-coach-text-muted hover:bg-coach-bg disabled:opacity-40"
-        >
-          {t('coach.endSession', 'Kết thúc phiên')}
-        </button>
       </div>
 
       {messages.length === 0 && !isStarting && (
         <div className="flex flex-1 items-center justify-center px-8 text-center text-sm text-coach-text-muted">
-          {t('coach.emptyState', 'Bắt đầu bằng cách chia sẻ điều đang ở trong đầu bạn lúc này.')}
+          {t('coach.emptyState')}
         </div>
       )}
 
       {sendMessage.isError && (
         <p className="px-4 pb-1 text-center text-xs text-red-500">
-          {t('coach.sendError', 'Không thể gửi tin nhắn lúc này. Vui lòng thử lại.')}
+          {t('coach.sendError')}
         </p>
       )}
 

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { usePeopleQuery, useCreatePersonMutation } from '../../queries/peopleQueryHook';
 import RelationshipMap from '../../components/RelationshipMap/RelationshipMap';
 import InsightTimelineList from '../../components/InsightTimeline/InsightTimelineList';
 import CoreValuesCard from '../../components/CoreValuesCard/CoreValuesCard';
 import PersonForm from '../../components/PersonForm/PersonForm';
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import { Button, ButtonLink } from '../../components/Button/Button';
 import { APP_ROUTES } from '../../constants/route';
 import { useAuth } from '../../providers/AuthProvider';
 import { completeOnboarding } from '../../services/userService';
@@ -24,11 +26,17 @@ const DashboardPage = () => {
   };
 
   return (
-    <div className="mx-auto flex max-w-2xl flex-col gap-8 bg-coach-bg px-4 py-6">
+    <div className="mx-auto flex max-w-2xl flex-col gap-10 bg-coach-bg px-4 py-8 sm:px-6">
       <div>
-        <h1 className="text-xl font-semibold text-coach-text">{t('dashboard.pageTitle', 'Về bạn')}</h1>
-        <p className="text-xs text-coach-text-muted">
-          {t('dashboard.pageSubtitle', 'Mọi thứ Coach đã hiểu về bạn — giá trị cốt lõi, những người quan trọng, và những insight đã đúc kết được.')}
+        <Breadcrumb
+          variant="light"
+          items={[{ label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME }, { label: t('breadcrumb.dashboard') }]}
+        />
+        <h1 className="mt-2 text-2xl font-bold text-coach-text [font-family:var(--font-family-heading)]">
+          {t('dashboard.pageTitle')}
+        </h1>
+        <p className="mt-1 text-sm text-coach-text-muted">
+          {t('dashboard.pageSubtitle')}
         </p>
       </div>
 
@@ -42,33 +50,26 @@ const DashboardPage = () => {
         <div className="mb-3 flex items-center justify-between">
           <div>
             <h2 className="text-lg font-semibold text-coach-text">
-              {t('dashboard.mapTitle', 'Bản đồ mối quan hệ')}
+              {t('dashboard.mapTitle')}
             </h2>
             <p className="text-xs text-coach-text-muted">
-              {t('dashboard.mapSubtitle', 'Được xây dựng dần từ những gì bạn chia sẻ với Coach.')}
+              {t('dashboard.mapSubtitle')}
             </p>
           </div>
           <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setIsAddingPerson((prev) => !prev)}
-              className="rounded-lg border border-coach-border px-3 py-1.5 text-xs font-medium text-coach-text hover:bg-coach-bg"
-            >
-              {t('dashboard.person.add', '+ Thêm người')}
-            </button>
-            <Link
-              to={APP_ROUTES.COACH_CHAT}
-              className="rounded-lg bg-coach-primary px-3 py-1.5 text-xs font-medium text-white"
-            >
-              {t('dashboard.talkToCoach', 'Trò chuyện với Coach')}
-            </Link>
+            <Button variant="secondary" size="sm" onClick={() => setIsAddingPerson((prev) => !prev)}>
+              {t('dashboard.person.add')}
+            </Button>
+            <ButtonLink to={APP_ROUTES.COACH_CHAT} variant="primary" size="sm">
+              {t('dashboard.talkToCoach')}
+            </ButtonLink>
           </div>
         </div>
 
         {isAddingPerson && (
           <div className="mb-3">
             <PersonForm
-              submitLabel={t('dashboard.person.add', '+ Thêm người')}
+              submitLabel={t('dashboard.person.add')}
               onCancel={() => setIsAddingPerson(false)}
               onSubmit={async (person) => {
                 await createPerson.mutateAsync(person);
@@ -79,21 +80,18 @@ const DashboardPage = () => {
         )}
 
         {isLoading ? (
-          <p className="text-sm text-coach-text-muted">{t('dashboard.loading', 'Đang tải...')}</p>
+          <p className="text-sm text-coach-text-muted">{t('dashboard.loading')}</p>
         ) : (
           <RelationshipMap
             people={people ?? []}
-            emptyLabel={t(
-              'dashboard.mapEmpty',
-              'Chưa có ai trong bản đồ — hãy chia sẻ về những người quan trọng với bạn khi trò chuyện với Coach.',
-            )}
+            emptyLabel={t('dashboard.mapEmpty')}
           />
         )}
       </section>
 
       <section>
         <h2 className="mb-3 text-lg font-semibold text-coach-text">
-          {t('dashboard.insightsTitle', 'Dòng thời gian Insight')}
+          {t('dashboard.insightsTitle')}
         </h2>
         <InsightTimelineList />
       </section>

--- a/src/pages/EntriesPage/EditEntryPage/EditEntryPage.tsx
+++ b/src/pages/EntriesPage/EditEntryPage/EditEntryPage.tsx
@@ -12,6 +12,7 @@ import { useUpdateEntryMutation } from '../../../queries/entriesQueryHook';
 import { APP_ROUTES } from '../../../constants/route';
 import { useSnackbar } from '../../../providers/SnackbarProvider';
 import Breadcrumb from '../../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../../components/Button/Button';
 import type { Entry } from '../../../models/entry';
 import './EditEntryPage.scss';
 
@@ -149,20 +150,24 @@ const EditEntryPage: React.FC = () => {
       {/* Floating Footer */}
       {selectedEmotions.length > 0 && (
         <div className={`safe-space__footer ${canSave ? 'safe-space__footer--active' : ''}`}>
-          <button
-            className="safe-space__back-btn"
+          <Button
+            variant="secondary"
+            size="sm"
+            className="!border-white/15 !bg-transparent !text-coach-bg hover:!bg-white/10"
             onClick={() => navigate(APP_ROUTES.ENTRIES_LIST)}
           >
             <LuArrowLeft size={16} />
             <span>{t('breadcrumb.journal')}</span>
-          </button>
+          </Button>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <div className="safe-space__privacy">
               <LuLock size={14} />
               <span>{t('newEntryPage.privacy')}</span>
             </div>
-            <button
-              className="safe-space__save-btn"
+            <Button
+              variant="primary"
+              size="md"
+              shape="pill"
               onClick={handleSave}
               disabled={!canSave || updateEntryMutation.isPending}
             >
@@ -174,7 +179,7 @@ const EditEntryPage: React.FC = () => {
                   <span>{t('newEntryPage.save')}</span>
                 </>
               )}
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/src/pages/EntriesPage/EntriesListPage/EntriesListPage.scss
+++ b/src/pages/EntriesPage/EntriesListPage/EntriesListPage.scss
@@ -214,44 +214,6 @@
     line-height: var(--line-height-relaxed);
   }
 
-  // ── CTA BUTTON (solid + outline variants) ──
-  &__cta-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-lg);
-    padding: var(--spacing-sm) var(--spacing-lg);
-    border: 1.5px solid transparent;
-    border-radius: var(--border-radius-md);
-    background: var(--c-secondary);
-    color: var(--c-white);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-bold);
-    cursor: pointer;
-    transition: all var(--transition-normal);
-
-    &:hover {
-      background: var(--c-secondary-hover);
-      transform: translateY(-1px);
-      box-shadow: 0 4px 20px color-mix(in srgb, var(--c-secondary), transparent 60%);
-    }
-
-    &--outline {
-      background: transparent;
-      border-color: rgba(255, 255, 255, 0.2);
-      color: var(--c-text-on-dark);
-      margin-top: 0;
-
-      &:hover {
-        background: rgba(255, 255, 255, 0.06);
-        border-color: rgba(255, 255, 255, 0.4);
-        box-shadow: none;
-        transform: translateY(-1px);
-      }
-    }
-  }
-
   // ── LOAD MORE ──
   &__load-more {
     display: flex;

--- a/src/pages/EntriesPage/EntriesListPage/EntriesListPage.tsx
+++ b/src/pages/EntriesPage/EntriesListPage/EntriesListPage.tsx
@@ -9,6 +9,7 @@ import { useEntriesInfiniteQuery } from '../../../queries/entriesQueryHook';
 import type { Entry } from '../../../models/entry';
 import EntryCard from '../components/EntryCard/EntryCard';
 import Breadcrumb from '../../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../../components/Button/Button';
 import { APP_ROUTES } from '../../../constants/route';
 import './EntriesListPage.scss';
 
@@ -116,7 +117,6 @@ const EntriesListPage: React.FC = () => {
           ]}
         />
         <h1 className="entries-page__title">{t('entriesPage.title')}</h1>
-        <p className="entries-page__subtitle">{t('entriesPage.laoTzuQuote')}</p>
       </div>
 
       {/* Content */}
@@ -162,13 +162,16 @@ const EntriesListPage: React.FC = () => {
           <div className="entries-page__empty">
             <p className="entries-page__empty-title">{t('entriesPage.emptyState')}</p>
             <p className="entries-page__empty-hint">{t('entriesPage.emptyStateHint')}</p>
-            <button
-              className="entries-page__cta-btn"
+            <Button
+              variant="primary"
+              size="md"
+              shape="pill"
+              className="mt-4"
               onClick={() => navigate(APP_ROUTES.ENTRIES_NEW)}
             >
               <LuPenLine size={16} />
-              <span>{t('innerversePage.sections.safeSpace.cta')}</span>
-            </button>
+              <span>{t('entriesPage.startWriting')}</span>
+            </Button>
           </div>
         )}
 
@@ -193,12 +196,15 @@ const EntriesListPage: React.FC = () => {
           {(isFetchingNextPage || isLoading) && (<CircularProgress size={24} sx={{ mb: 1 }} />)}
 
           {!isLoading && hasNextPage && (
-            <button
-              className="entries-page__cta-btn entries-page__cta-btn--outline"
+            <Button
+              variant="secondary"
+              size="md"
+              shape="pill"
               onClick={handleLoadMore}
+              className="!border-white/20 !bg-transparent !text-coach-bg hover:!bg-white/10"
             >
               {t('entriesPage.loadMore')}
-            </button>
+            </Button>
           )}
 
           {entries.length > 0 && (

--- a/src/pages/EntriesPage/NewEntryPage/NewEntryPage.scss
+++ b/src/pages/EntriesPage/NewEntryPage/NewEntryPage.scss
@@ -113,13 +113,6 @@
     background: color-mix(in srgb, var(--c-background-dark), transparent 10%);
     backdrop-filter: blur(16px);
     border-top: 1px solid var(--c-border-dark);
-
-    &--active {
-      .safe-space__save-btn {
-        opacity: 1;
-        pointer-events: auto;
-      }
-    }
   }
 
   &__privacy {
@@ -128,54 +121,6 @@
     gap: 6px;
     font-size: var(--font-size-xs);
     color: var(--c-text-muted-on-dark);
-  }
-
-  &__back-btn {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: var(--spacing-xs) var(--spacing-sm);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    border-radius: var(--border-radius-sm);
-    background: transparent;
-    color: var(--c-text-muted-on-dark);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-bold);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-
-    &:hover {
-      border-color: rgba(255, 255, 255, 0.3);
-      color: var(--c-text-on-dark);
-    }
-  }
-
-  &__save-btn {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-    padding: var(--spacing-sm) var(--spacing-lg);
-    border: none;
-    border-radius: var(--border-radius-md);
-    background: var(--c-secondary);
-    color: var(--c-white);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-bold);
-    cursor: pointer;
-    transition: all var(--transition-normal);
-    opacity: 0.4;
-    pointer-events: none;
-
-    &:not(:disabled):hover {
-      background: var(--c-secondary-hover);
-      transform: translateY(-1px);
-      box-shadow: 0 4px 20px color-mix(in srgb, var(--c-secondary), transparent 60%);
-    }
-
-    &:disabled {
-      opacity: 0.4;
-      cursor: not-allowed;
-    }
   }
 
   // Override MimoHeader for dark background

--- a/src/pages/EntriesPage/NewEntryPage/NewEntryPage.tsx
+++ b/src/pages/EntriesPage/NewEntryPage/NewEntryPage.tsx
@@ -13,6 +13,7 @@ import { entriesService } from '../../../services/entriesService';
 import { APP_ROUTES } from '../../../constants/route';
 import { useSnackbar } from '../../../providers/SnackbarProvider';
 import Breadcrumb from '../../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../../components/Button/Button';
 
 const NewEntryPage: React.FC = () => {
   const navigate = useNavigate();
@@ -134,11 +135,7 @@ const NewEntryPage: React.FC = () => {
             <LuLock size={14} />
             <span>{t('newEntryPage.privacy')}</span>
           </div>
-          <button
-            className="safe-space__save-btn"
-            onClick={handleSave}
-            disabled={!canSave || isLoading}
-          >
+          <Button variant="primary" size="md" shape="pill" onClick={handleSave} disabled={!canSave || isLoading}>
             {isLoading ? (
               <span>{t('newEntryPage.saving')}</span>
             ) : (
@@ -147,7 +144,7 @@ const NewEntryPage: React.FC = () => {
                 <span>{t('newEntryPage.save')}</span>
               </>
             )}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/pages/LoginPage/LoginPage.scss
+++ b/src/pages/LoginPage/LoginPage.scss
@@ -3,6 +3,9 @@
 @use '../../styles/_responsive' as *;
 
 // === BACKGROUND LAYER ===
+// Same garden gradient + soft ambient glow language as the homepage
+// (MimoLandingPage.scss / EntriesListPage.scss __glow) — kept visually
+// part of the same product instead of the old Innerverse/Outerverse split.
 .login-bg {
   position: fixed;
   inset: 0;
@@ -13,8 +16,7 @@
   &__split {
     position: absolute;
     inset: 0;
-    background: linear-gradient(135deg, #0B121E 50%, #F9F6F0 50%);
-    transition: background 0.7s ease;
+    background: linear-gradient(180deg, var(--garden-sky) 0%, #f0f7eb 100%);
   }
 
   &__orb {
@@ -26,9 +28,9 @@
       left: -10%;
       width: 50%;
       height: 50%;
-      background: #3B82F6;
-      filter: blur(60px);
-      opacity: 0.3;
+      background: var(--garden-grass-light);
+      filter: blur(80px);
+      opacity: 0.35;
     }
 
     &--orange {
@@ -36,9 +38,9 @@
       right: -10%;
       width: 50%;
       height: 50%;
-      background: #FDBA74;
-      filter: blur(60px);
-      opacity: 0.4;
+      background: var(--garden-bloom);
+      filter: blur(80px);
+      opacity: 0.25;
     }
   }
 }
@@ -78,71 +80,47 @@
   @include margin-responsive(0 0 var(--spacing-xl), 0 0 var(--spacing-2xl), 0 0 var(--spacing-3xl));
 
   &__title {
-    font-family: var(--font-family-primary), sans-serif;
-    color: white;
-    mix-blend-mode: difference;
-    letter-spacing: -0.02em;
+    font-family: var(--font-family-heading), serif;
+    letter-spacing: -0.01em;
     line-height: var(--line-height-tight);
     margin: 0 0 var(--spacing-sm);
-    @include font-responsive(2.8rem, 3.2rem, 3.6rem);
+    background: var(--grad-garden-text);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    @include font-responsive(2.4rem, 2.8rem, 3.2rem);
   }
 
   &__acronym {
     font-size: var(--font-size-xs);
-    letter-spacing: 0.12em;
-    color: rgba(255, 255, 255, 0.6);
-    mix-blend-mode: difference;
+    font-weight: var(--font-weight-normal);
+    letter-spacing: 0.1em;
+    color: var(--garden-text-muted);
     margin: 0 0 var(--spacing-xs);
   }
 
   &__subtitle {
     text-transform: uppercase;
-    letter-spacing: 0.3em;
-    color: rgba(255, 255, 255, 0.7);
-    mix-blend-mode: difference;
-    opacity: 0.8;
+    letter-spacing: 0.25em;
+    color: var(--garden-text-muted);
+    opacity: 0.9;
     margin: 0;
     @include font-responsive(var(--font-size-xs), var(--font-size-xs), var(--font-size-sm));
   }
 }
 
 // === FORM AREA ===
+// A contained card, matching the parchment-panel style used by FrameworkPanels
+// on the homepage, instead of fields floating loosely on the background.
 .login-body {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
-}
-
-// === GOOGLE BUTTON ===
-.login-google-btn {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-sm);
-  background: var(--c-white);
-  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  border: 1px solid rgba(91, 140, 90, 0.15);
   border-radius: var(--border-radius-xl);
-  padding: var(--spacing-md) var(--spacing-lg);
-  box-shadow: var(--shadow-sm);
-  cursor: pointer;
-  transition: all var(--transition-normal);
-  @include font-responsive(var(--font-size-sm), var(--font-size-base), var(--font-size-base));
-  font-weight: var(--font-weight-medium);
-  color: var(--c-text-on-surface);
-
-  &:hover {
-    box-shadow: var(--shadow-md);
-    transform: translateY(-1px);
-  }
-
-  &:active {
-    transform: scale(0.98);
-  }
-
-  svg {
-    flex-shrink: 0;
-  }
+  box-shadow: var(--shadow-md);
+  @include padding-responsive(var(--spacing-lg), var(--spacing-xl), var(--spacing-xl));
 }
 
 // Google OAuth wrapper (for the actual GoogleLogin component)
@@ -173,7 +151,7 @@
   &__line {
     flex: 1;
     height: 1px;
-    background: rgba(148, 163, 184, 0.4);
+    background: rgba(91, 140, 90, 0.2);
   }
 
   &__text {
@@ -181,7 +159,7 @@
     margin: 0 var(--spacing-md);
     text-transform: uppercase;
     letter-spacing: 0.15em;
-    color: rgba(148, 163, 184, 0.7);
+    color: var(--garden-text-muted);
     font-weight: var(--font-weight-medium);
     @include font-responsive(var(--font-size-xs), var(--font-size-xs), var(--font-size-xs));
   }
@@ -210,13 +188,13 @@
     display: block;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: rgba(100, 116, 139, 0.85);
+    color: var(--garden-text-muted);
     font-weight: var(--font-weight-semibold);
     @include font-responsive(var(--font-size-xs), var(--font-size-xs), var(--font-size-xs));
   }
 
   &__forgot {
-    color: var(--c-background-dark);
+    color: var(--garden-grass);
     font-weight: var(--font-weight-medium);
     text-decoration: none;
     @include font-responsive(var(--font-size-xs), var(--font-size-xs), var(--font-size-xs));
@@ -233,24 +211,23 @@
   &__input {
     width: 100%;
     padding: var(--spacing-md);
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: var(--garden-sky);
+    border: 1px solid rgba(91, 140, 90, 0.25);
     border-radius: var(--border-radius-xl);
     outline: none;
-    color: #1e293b;
+    color: var(--garden-text);
     font-family: var(--font-family-primary), sans-serif;
     transition: all var(--transition-normal);
     @include font-responsive(var(--font-size-sm), var(--font-size-base), var(--font-size-base));
 
     &::placeholder {
-      color: rgba(148, 163, 184, 0.6);
+      color: var(--garden-text-muted);
+      opacity: 0.6;
     }
 
     &:focus {
-      border-color: var(--c-background-dark);
-      box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.08);
+      border-color: var(--garden-grass);
+      box-shadow: 0 0 0 3px rgba(91, 140, 90, 0.12);
     }
   }
 
@@ -262,7 +239,7 @@
     background: none;
     border: none;
     padding: 0;
-    color: rgba(148, 163, 184, 0.7);
+    color: var(--garden-text-muted);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -272,43 +249,11 @@
     box-shadow: none;
 
     &:hover {
-      color: var(--c-text-on-surface);
+      color: var(--garden-text);
       background: none;
       transform: translateY(-50%);
       box-shadow: none;
     }
-  }
-}
-
-// === SUBMIT BUTTON ===
-.login-submit-btn {
-  width: 100%;
-  background: var(--c-background-dark);
-  color: var(--c-white);
-  padding: var(--spacing-md);
-  border-radius: var(--border-radius-xl);
-  border: none;
-  font-weight: var(--font-weight-semibold);
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
-  cursor: pointer;
-  transition: all var(--transition-normal);
-  margin-top: var(--spacing-xs);
-  @include font-responsive(var(--font-size-sm), var(--font-size-base), var(--font-size-base));
-
-  &:hover {
-    box-shadow: 0 14px 35px rgba(15, 23, 42, 0.3);
-    transform: translateY(-2px);
-    background: var(--c-background-dark);
-  }
-
-  &:active {
-    transform: scale(0.98);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-    transform: none;
   }
 }
 
@@ -326,8 +271,7 @@
 // === LOADING ===
 .login-loading {
   text-align: center;
-  color: rgba(255, 255, 255, 0.7);
-  mix-blend-mode: difference;
+  color: var(--garden-text-muted);
   @include font-responsive(var(--font-size-xs), var(--font-size-sm), var(--font-size-sm));
 }
 
@@ -338,15 +282,14 @@
   text-align: center;
 
   &__signup {
-    color: rgba(148, 163, 184, 0.8);
+    color: var(--garden-text-muted);
     margin-bottom: var(--spacing-lg);
     @include font-responsive(var(--font-size-sm), var(--font-size-sm), var(--font-size-base));
 
     a {
-      color: var(--c-background-dark);
+      color: var(--garden-grass);
       font-weight: var(--font-weight-semibold);
       text-decoration: none;
-      mix-blend-mode: difference;
 
       &:hover {
         text-decoration: underline;
@@ -364,17 +307,17 @@
     a {
       text-transform: uppercase;
       letter-spacing: 0.15em;
-      color: rgba(148, 163, 184, 0.6);
+      color: var(--garden-text-muted);
       text-decoration: none;
       transition: color var(--transition-fast);
 
       &:hover {
-        color: var(--c-background-dark);
+        color: var(--garden-grass);
       }
     }
 
     &-dot {
-      color: rgba(148, 163, 184, 0.4);
+      color: rgba(91, 140, 90, 0.35);
     }
   }
 }
@@ -383,8 +326,8 @@
 .login-decor {
   position: fixed;
   pointer-events: none;
-  opacity: 0.2;
-  color: rgba(148, 163, 184, 0.6);
+  opacity: 0.25;
+  color: var(--garden-grass-light);
   display: none;
 
   @include respond-to(laptop) {

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -7,6 +7,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { APP_ROUTES } from '../../constants/route';
 import { useAuth } from '../../providers/AuthProvider';
+import { Button } from '../../components/Button/Button';
 import './LoginPage.scss';
 
 const LoginPage = () => {
@@ -43,7 +44,7 @@ const LoginPage = () => {
 
     const handleGoogleSuccess = async (codeResponse: CodeResponse) => {
         if (!codeResponse.code) {
-            setError('Did not receive authorization code from Google.');
+            setError(t('auth.errors.googleCodeMissing'));
             return;
         }
 
@@ -59,7 +60,7 @@ const LoginPage = () => {
                 ? error.response?.data?.message ?? error.message
                 : error instanceof Error
                     ? error.message
-                    : 'Network Error: Login failed during backend authentication step.';
+                    : t('auth.errors.networkError');
             setError(errorMessage);
         } finally {
             setIsLoggingIn(false);
@@ -67,7 +68,7 @@ const LoginPage = () => {
     };
 
     const handleGoogleError = () => {
-        setError('Google authentication failed. Please try again.');
+        setError(t('auth.errors.googleFailed'));
     };
 
     const loginWithGoogle = useGoogleLogin({
@@ -80,7 +81,7 @@ const LoginPage = () => {
         e.preventDefault();
 
         if (!username.trim() || !password.trim()) {
-            setError('Please enter both username and password.');
+            setError(t('auth.errors.usernamePasswordRequired'));
             return;
         }
 
@@ -94,7 +95,7 @@ const LoginPage = () => {
             console.error('LoginPage: Credential login error:', error);
             const errorMessage = error instanceof Error
                 ? error.message
-                : 'Login failed. Please check your credentials.';
+                : t('auth.errors.loginFailed');
             setError(errorMessage);
         } finally {
             setIsLoggingIn(false);
@@ -111,7 +112,7 @@ const LoginPage = () => {
                     <div className="login-bg__orb login-bg__orb--orange" />
                 </div>
                 <div className="login-main">
-                    <div className="login-loading">Signing in...</div>
+                    <div className="login-loading">{t('auth.signingIn')}</div>
                 </div>
             </main>
         );
@@ -144,21 +145,23 @@ const LoginPage = () => {
 
                     {/* Google Login */}
                     <div className="login-google-wrapper">
-                        <button
-                            type="button"
-                            className="login-google-btn"
+                        <Button
+                            variant="secondary"
+                            size="lg"
+                            shape="pill"
+                            className="w-full shadow-sm hover:shadow-md"
                             onClick={() => loginWithGoogle()}
                             disabled={isLoggingIn}
                         >
                             <FcGoogle size={24} />
                             {t('auth.googleLogin')}
-                        </button>
+                        </Button>
                     </div>
 
                     {/* Divider */}
                     <div className="login-divider">
                         <div className="login-divider__line" />
-                        <span className="login-divider__text">or</span>
+                        <span className="login-divider__text">{t('auth.or')}</span>
                         <div className="login-divider__line" />
                     </div>
 
@@ -173,7 +176,7 @@ const LoginPage = () => {
                                 className="login-field__input"
                                 id="login-username"
                                 type="text"
-                                placeholder="Enter your username"
+                                placeholder={t('auth.usernamePlaceholder')}
                                 value={username}
                                 onChange={(e) => setUsername(e.target.value)}
                                 autoComplete="username"
@@ -187,7 +190,7 @@ const LoginPage = () => {
                                     {t('auth.password')}
                                 </label>
                                 <a className="login-field__forgot" href="#">
-                                    Forgot?
+                                    {t('auth.forgotPassword')}
                                 </a>
                             </div>
                             <div className="login-field__input-wrapper">
@@ -212,13 +215,16 @@ const LoginPage = () => {
                         </div>
 
                         {/* Submit */}
-                        <button
+                        <Button
                             type="submit"
-                            className="login-submit-btn"
+                            variant="primary"
+                            size="lg"
+                            shape="pill"
+                            className="mt-1 w-full"
                             disabled={isLoggingIn}
                         >
                             {isLoggingIn ? '...' : t('auth.loginButton')}
-                        </button>
+                        </Button>
                     </form>
                 </div>
 
@@ -229,9 +235,9 @@ const LoginPage = () => {
                         <Link to={APP_ROUTES.SIGNUP}>{t('auth.signupLink')}</Link>
                     </p>
                     <div className="login-footer__links">
-                        <a href="#">Privacy Policy</a>
+                        <a href="#">{t('auth.privacyPolicy')}</a>
                         <span className="login-footer__links-dot">•</span>
-                        <a href="#">Terms of Service</a>
+                        <a href="#">{t('auth.termsOfService')}</a>
                     </div>
                 </footer>
             </div>

--- a/src/pages/LoginPage/__tests__/LoginPage.test.tsx
+++ b/src/pages/LoginPage/__tests__/LoginPage.test.tsx
@@ -37,15 +37,25 @@ vi.mock('react-i18next', () => ({
     useTranslation: () => ({
         t: (key: string) => {
             const labels: Record<string, string> = {
-                'brand.name': 'MimoSe',
-                'brand.acronym': 'Make Sense Of ME',
-                'brand.welcome': 'Chào mừng trở lại khu vườn của bạn.',
+                'brand.name': 'Aura Self AI',
+                'brand.acronym': 'AI Coach for Self-Understanding',
+                'brand.welcome': 'Welcome back to Aura Self AI.',
                 'auth.username': 'Username',
                 'auth.password': 'Password',
                 'auth.loginButton': 'Sign In',
                 'auth.googleLogin': 'Sign in with Google',
                 'auth.noAccount': "Don't have an account?",
                 'auth.signupLink': 'Start your journey',
+                'auth.usernamePlaceholder': 'Enter your username',
+                'auth.forgotPassword': 'Forgot?',
+                'auth.or': 'or',
+                'auth.signingIn': 'Signing in...',
+                'auth.privacyPolicy': 'Privacy Policy',
+                'auth.termsOfService': 'Terms of Service',
+                'auth.errors.usernamePasswordRequired': 'Please enter both username and password.',
+                'auth.errors.loginFailed': 'Login failed. Please check your credentials.',
+                'auth.errors.googleCodeMissing': 'Did not receive authorization code from Google.',
+                'auth.errors.googleFailed': 'Google authentication failed. Please try again.',
             };
             return labels[key] ?? key;
         },
@@ -87,8 +97,8 @@ describe('LoginPage', () => {
         it('should render the page title and subtitle', () => {
             renderLoginPage();
 
-            expect(screen.getByText('MimoSe')).toBeInTheDocument();
-            expect(screen.getByText('Chào mừng trở lại khu vườn của bạn.')).toBeInTheDocument();
+            expect(screen.getByText('Aura Self AI')).toBeInTheDocument();
+            expect(screen.getByText('Welcome back to Aura Self AI.')).toBeInTheDocument();
         });
 
         it('should render the username and password fields', () => {

--- a/src/pages/MimoLandingPage/GardenHero/GardenHero.scss
+++ b/src/pages/MimoLandingPage/GardenHero/GardenHero.scss
@@ -51,6 +51,7 @@
     margin-bottom: 0;
   }
 
+
   &__mimo {
     margin-top: var(--spacing-lg);
     opacity: 0.85;

--- a/src/pages/MimoLandingPage/GardenHero/GardenHero.tsx
+++ b/src/pages/MimoLandingPage/GardenHero/GardenHero.tsx
@@ -1,9 +1,19 @@
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import MimoCharacter from '../../../components/MimoCharacter/MimoCharacter';
+import { useAuth } from '../../../providers/AuthProvider';
+import { APP_ROUTES } from '../../../constants/route';
+import { Button } from '../../../components/Button/Button';
 import './GardenHero.scss';
 
 const GardenHero = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { currentUser } = useAuth();
+
+  const handleCta = () => {
+    navigate(currentUser ? APP_ROUTES.COACH_CHAT : APP_ROUTES.SIGNUP);
+  };
 
   return (
     <section className="garden-hero">
@@ -13,6 +23,9 @@ const GardenHero = () => {
         </p>
         <h1 className="garden-hero__slogan">{t('brand.slogan')}</h1>
         <p className="garden-hero__description">{t('brand.description')}</p>
+        <Button variant="primary" size="lg" shape="pill" className="mt-6" onClick={handleCta}>
+          {t(currentUser ? 'brand.ctaLoggedIn' : 'brand.ctaLoggedOut')}
+        </Button>
       </div>
       <div className="garden-hero__mimo" aria-hidden="true">
         <MimoCharacter theme="bridge" />

--- a/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -6,6 +6,7 @@ import { useCompleteOnboardingMutation } from '../../queries/authQueryHook';
 import type { RelationshipType } from '../../models/person';
 import { APP_ROUTES } from '../../constants/route';
 import { CORE_VALUE_KEYS } from '../../constants/coreValues';
+import { Button } from '../../components/Button/Button';
 
 const RELATIONSHIP_TYPES: RelationshipType[] = ['FAMILY', 'FRIEND', 'PARTNER', 'COLLEAGUE', 'MANAGER', 'OTHER'];
 
@@ -48,7 +49,7 @@ const OnboardingPage = () => {
 
   const handleContinue = () => {
     if (selectedValues.length === 0) {
-      setError(t('onboarding.selectAtLeastOne', 'Chọn ít nhất một giá trị để tiếp tục.'));
+      setError(t('onboarding.selectAtLeastOne'));
       return;
     }
     setError(null);
@@ -77,7 +78,7 @@ const OnboardingPage = () => {
           navigate(APP_ROUTES.COACH_CHAT);
         },
         onError: () => {
-          setError(t('onboarding.submitError', 'Có lỗi xảy ra, vui lòng thử lại.'));
+          setError(t('onboarding.submitError'));
         },
       },
     );
@@ -86,7 +87,7 @@ const OnboardingPage = () => {
   const handleSubmit = () => {
     const validPeople = people.filter((row) => row.name.trim().length > 0);
     if (validPeople.length === 0) {
-      setError(t('onboarding.addAtLeastOnePerson', 'Thêm ít nhất một người, hoặc bấm "Bỏ qua, vào Coach luôn".'));
+      setError(t('onboarding.addAtLeastOnePerson'));
       return;
     }
     submit(validPeople);
@@ -101,17 +102,17 @@ const OnboardingPage = () => {
     <div className="mx-auto flex min-h-[calc(100dvh-64px)] max-w-lg flex-col justify-center gap-6 bg-coach-bg px-4 py-8">
       <div>
         <p className="text-xs font-medium text-coach-primary">
-          {t('onboarding.step', 'Bước {{current}}/2', { current: step })}
+          {t('onboarding.step', { current: step })}
         </p>
         <h1 className="mt-1 text-xl font-semibold text-coach-text">
           {step === 1
-            ? t('onboarding.step1Title', 'Điều gì quan trọng với bạn?')
-            : t('onboarding.step2Title', 'Ai là người quan trọng với bạn?')}
+            ? t('onboarding.step1Title')
+            : t('onboarding.step2Title')}
         </h1>
         <p className="mt-1 text-sm text-coach-text-muted">
           {step === 1
-            ? t('onboarding.step1Subtitle', 'Chọn những giá trị cốt lõi cộng hưởng với bạn nhất.')
-            : t('onboarding.step2Subtitle', 'Thêm 3-5 người bạn muốn theo dõi mối quan hệ cùng.')}
+            ? t('onboarding.step1Subtitle')
+            : t('onboarding.step2Subtitle')}
         </p>
       </div>
 
@@ -144,7 +145,7 @@ const OnboardingPage = () => {
                   type="text"
                   value={row.name}
                   onChange={(e) => updatePerson(index, { name: e.target.value })}
-                  placeholder={t('onboarding.namePlaceholder', 'Tên')}
+                  placeholder={t('onboarding.namePlaceholder')}
                   className="flex-1 rounded-lg border border-coach-border bg-coach-bg px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
                 />
                 <select
@@ -162,8 +163,8 @@ const OnboardingPage = () => {
                   <button
                     type="button"
                     onClick={() => removePersonRow(index)}
-                    className="px-1.5 text-coach-text-muted hover:text-coach-text"
-                    aria-label={t('onboarding.removePerson', 'Xóa') as string}
+                    className="cursor-pointer bg-transparent px-1.5 text-coach-text-muted transition-colors hover:text-coach-text"
+                    aria-label={t('onboarding.removePerson') as string}
                   >
                     ✕
                   </button>
@@ -173,13 +174,14 @@ const OnboardingPage = () => {
           ))}
 
           {people.length < 5 && (
-            <button
-              type="button"
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={addPersonRow}
-              className="self-start rounded-lg border border-dashed border-coach-border px-3 py-1.5 text-xs font-medium text-coach-text-muted hover:bg-coach-surface"
+              className="self-start border-dashed"
             >
-              {t('onboarding.addPerson', '+ Thêm người')}
-            </button>
+              {t('onboarding.addPerson')}
+            </Button>
           )}
         </div>
       )}
@@ -188,41 +190,33 @@ const OnboardingPage = () => {
 
       <div className="flex items-center justify-between">
         {step === 2 ? (
-          <button
-            type="button"
-            onClick={() => setStep(1)}
-            className="text-sm font-medium text-coach-text-muted hover:text-coach-text"
-          >
-            {t('onboarding.back', 'Quay lại')}
-          </button>
+          <Button variant="ghost" size="sm" onClick={() => setStep(1)} className="!text-coach-text-muted">
+            {t('onboarding.back')}
+          </Button>
         ) : (
           <span />
         )}
 
-        <button
-          type="button"
-          onClick={step === 1 ? handleContinue : handleSubmit}
-          disabled={mutation.isPending}
-          className="rounded-xl bg-coach-primary px-5 py-2.5 text-sm font-medium text-white disabled:opacity-50"
-        >
+        <Button variant="primary" size="md" onClick={step === 1 ? handleContinue : handleSubmit} disabled={mutation.isPending}>
           {step === 1
-            ? t('onboarding.continue', 'Tiếp tục')
+            ? t('onboarding.continue')
             : mutation.isPending
-              ? t('onboarding.submitting', 'Đang lưu...')
-              : t('onboarding.finish', 'Hoàn tất')}
-        </button>
+              ? t('onboarding.submitting')
+              : t('onboarding.finish')}
+        </Button>
       </div>
 
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={step === 1 ? handleSkipStep1 : handleSkipStep2}
         disabled={mutation.isPending}
-        className="self-center text-xs text-coach-text-muted underline-offset-2 hover:underline disabled:opacity-50"
+        className="!text-coach-text-muted self-center"
       >
         {step === 1
-          ? t('onboarding.skipStep', 'Bỏ qua bước này')
-          : t('onboarding.skipToCoach', 'Bỏ qua, vào Coach luôn')}
-      </button>
+          ? t('onboarding.skipStep')
+          : t('onboarding.skipToCoach')}
+      </Button>
     </div>
   );
 };

--- a/src/pages/ProfilePage/ProfilePage.scss
+++ b/src/pages/ProfilePage/ProfilePage.scss
@@ -415,24 +415,6 @@
     font-weight: var(--font-weight-medium);
   }
 
-  &__toggle {
-    padding: var(--spacing-xs) var(--spacing-md);
-    border: 1px solid var(--c-border);
-    border-radius: var(--border-radius-sm);
-    background: var(--c-surface);
-    color: var(--c-text-on-surface);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-
-    &:hover:not(:disabled) {
-      background-color: var(--c-surface);
-      border-color: var(--c-primary);
-      color: var(--c-primary);
-    }
-  }
-
   &__inline-edit {
     display: flex;
     align-items: center;
@@ -529,25 +511,4 @@
     }
   }
 
-  &__password-btn {
-    align-self: flex-start;
-    padding: var(--spacing-xs) var(--spacing-lg);
-    border: none;
-    border-radius: var(--border-radius-sm);
-    background: var(--c-primary);
-    color: var(--c-white);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-
-    &:hover {
-      background: var(--c-primary-hover);
-    }
-
-    &:disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
-    }
-  }
 }

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { LuLogOut, LuGlobe, LuBell, LuDownload, LuBookOpen, LuPencil, LuLock, LuCamera, LuCheck, LuX, LuTreePine } from 'react-icons/lu';
+import { LuLogOut, LuGlobe, LuBell, LuDownload, LuBookOpen, LuPencil, LuLock, LuCamera, LuCheck, LuX, LuMessageCircle } from 'react-icons/lu';
 import { useAuth } from '../../providers/AuthProvider';
 import { updateUserProfile, changePassword, uploadAvatar, completeOnboarding } from '../../services/userService';
 import CoreValuesCard from '../../components/CoreValuesCard/CoreValuesCard';
@@ -14,6 +14,7 @@ import ConfirmDialog from '../../components/ConfirmDialog/ConfirmDialog';
 import LanguageSwitcher from '../../components/LanguageSwitcher/LanguageSwitcher';
 import { APP_ROUTES } from '../../constants/route';
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../components/Button/Button';
 import SnackbarComponent from '../../components/Snackbar/Snackbar';
 import type { SnackbarType } from '../../components/Snackbar/Snackbar';
 import './ProfilePage.scss';
@@ -81,7 +82,7 @@ const ProfilePage: React.FC = () => {
 
     const handleSaveName = async () => {
         if (!editName.trim()) {
-            setNameError('Name cannot be empty.');
+            setNameError(t('profilePage.editName.emptyError'));
             return;
         }
         setNameLoading(true);
@@ -91,7 +92,7 @@ const ProfilePage: React.FC = () => {
             setCurrentUser(updatedUser);
             setIsEditingName(false);
         } catch (err) {
-            setNameError(err instanceof Error ? err.message : 'Failed to update name.');
+            setNameError(err instanceof Error ? err.message : t('profilePage.editName.updateError'));
         } finally {
             setNameLoading(false);
         }
@@ -108,7 +109,7 @@ const ProfilePage: React.FC = () => {
             const updatedUser = await completeOnboarding({ coreValues: values, people: [] });
             setCurrentUser(updatedUser);
         } catch (err) {
-            const message = err instanceof Error ? err.message : 'Failed to save core values.';
+            const message = err instanceof Error ? err.message : t('profilePage.coreValues.saveError');
             setSnackbar({ open: true, message, type: 'error' });
             throw err;
         }
@@ -120,22 +121,22 @@ const ProfilePage: React.FC = () => {
         setPasswordSuccess('');
 
         if (!currentPassword.trim() || !newPassword.trim()) {
-            setPasswordError('Please fill in all fields.');
+            setPasswordError(t('profilePage.changePassword.fillAllFields'));
             return;
         }
         if (newPassword !== confirmNewPassword) {
-            setPasswordError('New passwords do not match.');
+            setPasswordError(t('profilePage.changePassword.mismatch'));
             return;
         }
         if (newPassword.length < 6) {
-            setPasswordError('New password must be at least 6 characters.');
+            setPasswordError(t('profilePage.changePassword.tooShort'));
             return;
         }
 
         setPasswordLoading(true);
         try {
             await changePassword({ currentPassword, newPassword });
-            setPasswordSuccess('Password changed successfully.');
+            setPasswordSuccess(t('profilePage.changePassword.success'));
             setCurrentPassword('');
             setNewPassword('');
             setConfirmNewPassword('');
@@ -144,7 +145,7 @@ const ProfilePage: React.FC = () => {
                 setPasswordSuccess('');
             }, 2000);
         } catch (err) {
-            setPasswordError(err instanceof Error ? err.message : 'Failed to change password.');
+            setPasswordError(err instanceof Error ? err.message : t('profilePage.changePassword.error'));
         } finally {
             setPasswordLoading(false);
         }
@@ -165,7 +166,7 @@ const ProfilePage: React.FC = () => {
             setCurrentUser({ ...currentUser, pictureUrl });
         } catch (err) {
             console.error('Avatar upload failed:', err);
-            const message = err instanceof Error ? err.message : 'Failed to upload avatar. Please try again.';
+            const message = err instanceof Error ? err.message : t('profilePage.avatarError');
             setSnackbar({ open: true, message, type: 'error' });
         } finally {
             setAvatarLoading(false);
@@ -252,12 +253,12 @@ const ProfilePage: React.FC = () => {
                 <div className="profile-page__actions">
                     <div
                         className="profile-page__action-card profile-page__action-card--garden"
-                        onClick={() => navigate(APP_ROUTES.WELCOME)}
+                        onClick={() => navigate(APP_ROUTES.COACH_CHAT)}
                     >
-                        <div className="profile-page__action-card-icon"><LuTreePine size={20} /></div>
+                        <div className="profile-page__action-card-icon"><LuMessageCircle size={20} /></div>
                         <div className="profile-page__action-card-body">
-                            <span className="profile-page__action-card-title">{t('nav.garden')}</span>
-                            <span className="profile-page__action-card-desc">{t('brand.tagline')}</span>
+                            <span className="profile-page__action-card-title">{t('nav.coach')}</span>
+                            <span className="profile-page__action-card-desc">{t('coach.subtitle')}</span>
                         </div>
                     </div>
                     <div
@@ -267,7 +268,7 @@ const ProfilePage: React.FC = () => {
                         <div className="profile-page__action-card-icon"><LuBookOpen size={20} /></div>
                         <div className="profile-page__action-card-body">
                             <span className="profile-page__action-card-title">{t('zonePage.writeJournal')}</span>
-                            <span className="profile-page__action-card-desc">{t('garden.zones.reflection.description')}</span>
+                            <span className="profile-page__action-card-desc">{t('newEntryPage.subtitle')}</span>
                         </div>
                     </div>
                 </div>
@@ -328,10 +329,10 @@ const ProfilePage: React.FC = () => {
                         <div className="settings-list__item">
                             <div className="settings-list__left">
                                 <LuPencil size={18} />
-                                <span>Display Name</span>
+                                <span>{t('profilePage.editName.label')}</span>
                             </div>
                             {!isEditingName ? (
-                                <button className="settings-list__toggle" onClick={handleStartEditName}>Edit</button>
+                                <Button variant="ghost" size="sm" onClick={handleStartEditName}>{t('profilePage.editName.edit')}</Button>
                             ) : (
                                 <div className="settings-list__inline-edit">
                                     <input
@@ -357,44 +358,50 @@ const ProfilePage: React.FC = () => {
                                 <div className="settings-list__item">
                                     <div className="settings-list__left">
                                         <LuLock size={18} />
-                                        <span>Change Password</span>
+                                        <span>{t('profilePage.changePassword.label')}</span>
                                     </div>
-                                    <button className="settings-list__toggle" onClick={() => { setIsChangingPassword(!isChangingPassword); setPasswordError(''); setPasswordSuccess(''); }}>
-                                        {isChangingPassword ? 'Cancel' : 'Change'}
-                                    </button>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => { setIsChangingPassword(!isChangingPassword); setPasswordError(''); setPasswordSuccess(''); }}
+                                    >
+                                        {isChangingPassword ? t('profilePage.changePassword.cancel') : t('profilePage.changePassword.change')}
+                                    </Button>
                                 </div>
                                 {isChangingPassword && (
                                     <div className="settings-list__password-form">
                                         <input
                                             className="settings-list__password-input"
                                             type="password"
-                                            placeholder="Current password"
+                                            placeholder={t('profilePage.changePassword.currentPlaceholder')}
                                             value={currentPassword}
                                             onChange={(e) => setCurrentPassword(e.target.value)}
                                         />
                                         <input
                                             className="settings-list__password-input"
                                             type="password"
-                                            placeholder="New password"
+                                            placeholder={t('profilePage.changePassword.newPlaceholder')}
                                             value={newPassword}
                                             onChange={(e) => setNewPassword(e.target.value)}
                                         />
                                         <input
                                             className="settings-list__password-input"
                                             type="password"
-                                            placeholder="Confirm new password"
+                                            placeholder={t('profilePage.changePassword.confirmPlaceholder')}
                                             value={confirmNewPassword}
                                             onChange={(e) => setConfirmNewPassword(e.target.value)}
                                         />
                                         {passwordError && <div className="settings-list__error">{passwordError}</div>}
                                         {passwordSuccess && <div className="settings-list__success">{passwordSuccess}</div>}
-                                        <button
-                                            className="settings-list__password-btn"
+                                        <Button
+                                            variant="primary"
+                                            size="sm"
+                                            className="w-full"
                                             onClick={handleSavePassword}
                                             disabled={passwordLoading}
                                         >
-                                            {passwordLoading ? 'Saving...' : 'Save Password'}
-                                        </button>
+                                            {passwordLoading ? t('profilePage.changePassword.saving') : t('profilePage.changePassword.save')}
+                                        </Button>
                                     </div>
                                 )}
                             </>
@@ -412,14 +419,14 @@ const ProfilePage: React.FC = () => {
                                 <LuBell size={18} />
                                 <span>{t('profilePage.settings.notifications')}</span>
                             </div>
-                            <span className="settings-list__badge">Soon</span>
+                            <span className="settings-list__badge">{t('profilePage.settings.soon')}</span>
                         </div>
                         <div className="settings-list__item">
                             <div className="settings-list__left">
                                 <LuDownload size={18} />
                                 <span>{t('profilePage.settings.exportData')}</span>
                             </div>
-                            <span className="settings-list__badge">Soon</span>
+                            <span className="settings-list__badge">{t('profilePage.settings.soon')}</span>
                         </div>
                         <div className="settings-list__item settings-list__item--danger" onClick={() => setLogoutDialogOpen(true)}>
                             <div className="settings-list__left">

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -4,6 +4,7 @@ import {LuEye, LuEyeOff, LuGlobe, LuSparkles} from 'react-icons/lu';
 import {Link, useNavigate} from 'react-router-dom';
 import {APP_ROUTES} from '../../constants/route';
 import {useAuth} from '../../providers/AuthProvider';
+import {Button} from '../../components/Button/Button';
 import '../LoginPage/LoginPage.scss';
 import './SignupPage.scss';
 
@@ -26,17 +27,17 @@ const SignupPage = () => {
         e.preventDefault();
 
         if (!fullName.trim() || !username.trim() || !password.trim()) {
-            setError('Please fill in all fields.');
+            setError(t('auth.errors.fillAllFields'));
             return;
         }
 
         if (password !== confirmPassword) {
-            setError('Passwords do not match.');
+            setError(t('auth.errors.passwordMismatch'));
             return;
         }
 
         if (password.length < 6) {
-            setError('Password must be at least 6 characters.');
+            setError(t('auth.errors.passwordTooShort'));
             return;
         }
 
@@ -50,7 +51,7 @@ const SignupPage = () => {
             console.error('SignupPage: Signup error:', error);
             const errorMessage = error instanceof Error
                 ? error.message
-                : 'Signup failed. Please try again.';
+                : t('auth.errors.signupFailed');
             setError(errorMessage);
         } finally {
             setIsSubmitting(false);
@@ -87,13 +88,13 @@ const SignupPage = () => {
                         {/* Full Name */}
                         <div className="login-field">
                             <label className="login-field__label" htmlFor="signup-name">
-                                Full Name
+                                {t('auth.fullName')}
                             </label>
                             <input
                                 className="login-field__input"
                                 id="signup-name"
                                 type="text"
-                                placeholder="Your full name"
+                                placeholder={t('auth.fullNamePlaceholder')}
                                 value={fullName}
                                 onChange={(e) => setFullName(e.target.value)}
                                 autoComplete="name"
@@ -103,13 +104,13 @@ const SignupPage = () => {
                         {/* Username */}
                         <div className="login-field">
                             <label className="login-field__label" htmlFor="signup-username">
-                                Username
+                                {t('auth.username')}
                             </label>
                             <input
                                 className="login-field__input"
                                 id="signup-username"
                                 type="text"
-                                placeholder="Choose a username"
+                                placeholder={t('auth.usernameChoosePlaceholder')}
                                 value={username}
                                 onChange={(e) => setUsername(e.target.value)}
                                 autoComplete="username"
@@ -119,7 +120,7 @@ const SignupPage = () => {
                         {/* Password */}
                         <div className="login-field">
                             <label className="login-field__label" htmlFor="signup-password">
-                                Password
+                                {t('auth.password')}
                             </label>
                             <div className="login-field__input-wrapper">
                                 <input
@@ -145,7 +146,7 @@ const SignupPage = () => {
                         {/* Confirm Password */}
                         <div className="login-field">
                             <label className="login-field__label" htmlFor="signup-confirm">
-                                Confirm Password
+                                {t('auth.confirmPassword')}
                             </label>
                             <div className="login-field__input-wrapper">
                                 <input
@@ -169,26 +170,29 @@ const SignupPage = () => {
                         </div>
 
                         {/* Submit */}
-                        <button
+                        <Button
                             type="submit"
-                            className="login-submit-btn"
+                            variant="primary"
+                            size="lg"
+                            shape="pill"
+                            className="mt-1 w-full"
                             disabled={isSubmitting}
                         >
-                            {isSubmitting ? 'Creating account...' : 'Create Account'}
-                        </button>
+                            {isSubmitting ? t('auth.creatingAccount') : t('auth.signupButton')}
+                        </Button>
                     </form>
                 </div>
 
                 {/* Footer */}
                 <footer className="login-footer">
                     <p className="login-footer__signup">
-                        Already have an account?{' '}
-                        <Link to={APP_ROUTES.LOGIN}>Sign in</Link>
+                        {t('auth.hasAccount')}{' '}
+                        <Link to={APP_ROUTES.LOGIN}>{t('auth.loginLink')}</Link>
                     </p>
                     <div className="login-footer__links">
-                        <a href="#">Privacy Policy</a>
+                        <a href="#">{t('auth.privacyPolicy')}</a>
                         <span className="login-footer__links-dot">•</span>
-                        <a href="#">Terms of Service</a>
+                        <a href="#">{t('auth.termsOfService')}</a>
                     </div>
                 </footer>
             </div>

--- a/src/pages/SignupPage/__tests__/SignupPage.test.tsx
+++ b/src/pages/SignupPage/__tests__/SignupPage.test.tsx
@@ -32,9 +32,25 @@ vi.mock('react-i18next', () => ({
     useTranslation: () => ({
         t: (key: string) => {
             const labels: Record<string, string> = {
-                'brand.name': 'MimoSe',
-                'brand.acronym': 'Make Sense Of ME',
+                'brand.name': 'Aura Self AI',
+                'brand.acronym': 'AI Coach for Self-Understanding',
                 'auth.signupTitle': 'Tạo tài khoản',
+                'auth.fullName': 'Full Name',
+                'auth.username': 'Username',
+                'auth.password': 'Password',
+                'auth.confirmPassword': 'Confirm Password',
+                'auth.fullNamePlaceholder': 'Your full name',
+                'auth.usernameChoosePlaceholder': 'Choose a username',
+                'auth.signupButton': 'Create Account',
+                'auth.creatingAccount': 'Creating account...',
+                'auth.hasAccount': 'Already have an account?',
+                'auth.loginLink': 'Sign in',
+                'auth.privacyPolicy': 'Privacy Policy',
+                'auth.termsOfService': 'Terms of Service',
+                'auth.errors.fillAllFields': 'Please fill in all fields.',
+                'auth.errors.passwordMismatch': 'Passwords do not match.',
+                'auth.errors.passwordTooShort': 'Password must be at least 6 characters.',
+                'auth.errors.signupFailed': 'Signup failed. Please try again.',
             };
             return labels[key] ?? key;
         },
@@ -59,7 +75,7 @@ describe('SignupPage', () => {
         it('should render the page title and subtitle', () => {
             renderSignupPage();
 
-            expect(screen.getByText('MimoSe')).toBeInTheDocument();
+            expect(screen.getByText('Aura Self AI')).toBeInTheDocument();
             expect(screen.getByText('Tạo tài khoản')).toBeInTheDocument();
         });
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -154,6 +154,12 @@
   --nav-height-laptop: 70px;
   --nav-height-desktop: 80px;
 
+  // Generic header/footer chrome height, for pages (e.g. CoachChatPage) that need to
+  // size themselves to exactly fill the viewport below the fixed header / above the
+  // floating MobileFooter. Mirrors the breakpoints MainLayout/MobileFooter already use.
+  --header-h: var(--header-height-mobile);
+  --footer-h: calc(var(--nav-height-mobile) + 32px);
+
   // Z-index Scale
   --z-dropdown: 1000;
   --z-sticky: 1020;
@@ -213,6 +219,22 @@
     --border-radius-md: 16px;
     --border-radius-lg: 20px;
     --border-radius-xl: 32px;
+  }
+}
+
+// Header grows from mobile to desktop size at the same breakpoint MainLayout/GardenHero
+// use for their own --header-height-mobile / --header-height-desktop switch.
+@media screen and (min-width: 768px) {
+  :root {
+    --header-h: var(--header-height-desktop);
+  }
+}
+
+// MobileFooter is display:none from this width up (see MobileFooter.scss respond-to(laptop)),
+// so there's no floating footer chrome left to clear.
+@media screen and (min-width: 992px) {
+  :root {
+    --footer-h: 0px;
   }
 }
 


### PR DESCRIPTION
## Summary

Rebrand MimoSe → **Aura Self AI**, full EN/VI i18n coverage, responsive fixes, and a unified button design system across the whole app.

### Branding & homepage
- Rebrand copy from MimoSe/garden metaphor to Aura Self AI everywhere it's live (nav, breadcrumb, footer, `notFound`, `index.html` title/meta) — internal component/route/CSS-class names left untouched, this is a copy-only rename.
- Redesigned the homepage hero + 3 framework panels around what's actually shipped (AI Coach, Relationship Map, Insights) instead of dead Energy/Action-Protocol features that have no route anymore. Added a real CTA and made each panel link to its live feature.
- Renamed "Journal" → **Reflectly** / "Đúc kết" and "Dashboard"/"Về bạn" → **Insights** / "Thấu hiểu" (product decision made during this session).
- Redesigned Login/Signup off the legacy Innerverse/Outerverse dark navy/orange split background onto the garden palette the homepage already uses, so auth pages feel like the same product.

### i18n
- `en.json` was missing 149 of 340 keys (whole namespaces gone: onboarding, coach, brand, zonePage, emotionPage, notFound, auth). Backfilled to full 100% key parity.
- Removed every hardcoded-Vietnamese `t()` fallback default across 8 components (they were masking the missing-EN problem).
- Converted ~40 hardcoded English strings on Login/Signup/Profile to real i18n keys — those two pages were rendering VI and EN text simultaneously regardless of selected language.
- Persisted the language choice to `localStorage` (previously reset to VI on every reload).
- Fixed a live bug: a button was rendering the raw untranslated key `innerversePage.sections.safeSpace.cta` (leftover from an even older naming scheme).

### Responsive & accessibility
- `CoachChatPage`'s `--header-h`/`--footer-h` CSS vars were referenced but never defined anywhere, always silently falling back to a hardcoded `64px` regardless of the real header/footer size — fixed by wiring them to the existing responsive `--header-height-*` tokens.
- Constrained the Coach chat panel to a centered `max-w-2xl` column (was stretching edge-to-edge on wide screens — a 1168px-wide input box with the Send button stranded at the far edge), matching the Dashboard's existing convention and common chat-UI patterns (ChatGPT/Claude/Slack).
- Added an auto-growing textarea to the chat composer.
- Added keyboard navigation + ARIA (`role="button"`, `aria-label`, `aria-pressed`, Enter/Space activation) to the SVG relationship-map nodes, which had none.

### Navigation
- Moved Profile out of the avatar dropdown into a visible top-level nav link.
- Added a "Home" nav link back to the landing page.

### Button consistency (root-cause fix)
Found and fixed the actual cause of the reported inconsistent buttons: `index.scss` had **un-layered** global `button`, `a`, and `h1`–`h3`/`p` rules. Per CSS cascade-layer rules, un-layered CSS always beats Tailwind's `@layer utilities` regardless of specificity — so any button/link that didn't explicitly restate *every* CSS property (background, hover background, color, etc.) silently fell back to the legacy garden colors, including on hover. Confirmed live: a "Core Values → Edit" button was rendering with a leaked brown hover background from the global reset.

- Wrapped those global rules in `@layer base` (matching a fix already applied to `button` alone, per a documented-but-incompletely-applied convention in `src/styles/README.md`) so Tailwind utilities reliably win.
- Added a single shared `Button`/`ButtonLink`/`ButtonAnchor` component (`src/components/Button/Button.tsx`) with 4 variants (primary/secondary/ghost/danger) that **always** declares an explicit `hover:bg-*`, so this class of bug can't reoccur.
- Swept the whole app onto it — homepage CTA, header CTA, framework panel links, Login/Signup/NotFound submit buttons, Onboarding, Coach chat, Dashboard/Insights, Reflectly (journal) list, Profile settings, New/Edit entry save buttons — removing the now-dead custom SCSS button classes along the way.

## Verification
- `tsc --noEmit` clean
- `npx vitest run` — 106/106 passing
- Walked the app live in-browser: Home → Login → Signup → Onboarding → Coach → Insights → Reflectly → Profile, in both languages, at mobile (375px) and desktop widths — no console errors, no horizontal overflow, language persists across reload
- Verified the button-color leak fix directly via computed styles before/after (brown leak → correct teal fill + white text) and confirmed the hover-state utility class is actually generated and layered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
