### PR TITLE
feat: Aura Insight Catcher — chat persistence, markdown, insight capture UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,9 @@
         "react-dom": "^19.2.0",
         "react-i18next": "^16.5.4",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.9.4"
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.9.4",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -2787,6 +2789,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2798,14 +2809,46 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2857,6 +2900,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.46.0",
@@ -3129,6 +3178,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.4.tgz",
@@ -3397,6 +3452,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3514,6 +3579,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3539,6 +3614,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -3596,6 +3711,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/concat-map": {
@@ -3762,6 +3887,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3782,7 +3920,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3800,6 +3937,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -4168,6 +4318,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4197,6 +4357,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4564,6 +4730,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4616,6 +4822,16 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4730,6 +4946,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4749,6 +4995,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -4774,6 +5030,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4782,6 +5048,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -5243,6 +5521,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5286,6 +5574,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5293,6 +5591,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -5311,6 +5891,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5514,6 +6657,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5700,6 +6868,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -5800,6 +6978,33 @@
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -5890,6 +7095,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -6111,6 +7382,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6124,6 +7405,20 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -6149,6 +7444,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylis": {
@@ -6344,6 +7657,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6421,6 +7754,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -6469,6 +7889,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -6847,6 +8295,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.9.4"
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.9.4",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",

--- a/src/components/Chat/ChatBubble.tsx
+++ b/src/components/Chat/ChatBubble.tsx
@@ -1,8 +1,34 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Components } from 'react-markdown';
 import type { ConversationMessage } from '../../models/conversation';
 
 interface ChatBubbleProps {
   message: ConversationMessage;
 }
+
+// Minimal, chat-bubble-scoped overrides — deliberately not pulling in @tailwindcss/typography
+// for one component. No rehype-raw plugin here on purpose: Aura's replies render as safe
+// markdown only, never raw HTML.
+const MARKDOWN_COMPONENTS: Components = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="mb-2 list-disc space-y-1 pl-5 last:mb-0">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-2 list-decimal space-y-1 pl-5 last:mb-0">{children}</ol>,
+  li: ({ children }) => <li>{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  a: ({ children, href }) => (
+    <a href={href} target="_blank" rel="noreferrer" className="underline underline-offset-2">
+      {children}
+    </a>
+  ),
+  code: ({ children }) => (
+    <code className="rounded bg-black/5 px-1 py-0.5 text-[0.85em]">{children}</code>
+  ),
+  h1: ({ children }) => <p className="mb-2 font-semibold last:mb-0">{children}</p>,
+  h2: ({ children }) => <p className="mb-2 font-semibold last:mb-0">{children}</p>,
+  h3: ({ children }) => <p className="mb-2 font-semibold last:mb-0">{children}</p>,
+};
 
 const ChatBubble = ({ message }: ChatBubbleProps) => {
   const isUser = message.role === 'USER';
@@ -10,13 +36,19 @@ const ChatBubble = ({ message }: ChatBubbleProps) => {
   return (
     <div className={`flex w-full ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
-        className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap ${
+        className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
           isUser
-            ? 'bg-coach-primary text-white rounded-br-sm'
+            ? 'bg-coach-primary text-white rounded-br-sm whitespace-pre-wrap'
             : 'bg-coach-surface text-coach-text border border-coach-border rounded-bl-sm'
         }`}
       >
-        {message.content}
+        {isUser ? (
+          message.content
+        ) : (
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MARKDOWN_COMPONENTS}>
+            {message.content}
+          </ReactMarkdown>
+        )}
       </div>
     </div>
   );

--- a/src/components/InsightCatcher/FrameworkEntryForm.tsx
+++ b/src/components/InsightCatcher/FrameworkEntryForm.tsx
@@ -1,0 +1,271 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../Button/Button';
+import { usePeopleQuery } from '../../queries/peopleQueryHook';
+import type { FrameworkType, LifePosition } from '../../models/savedFrameworkEntry';
+
+interface FrameworkEntryFormProps {
+  frameworkType: FrameworkType;
+  initialTitle?: string;
+  initialPayload?: Record<string, unknown>;
+  initialPersonId?: string;
+  onSubmit: (title: string | undefined, payload: Record<string, unknown>, personId?: string) => Promise<void>;
+  onCancel: () => void;
+  submitLabel: string;
+}
+
+const FIELD_CLASSES =
+  'w-full min-w-0 rounded-lg border border-coach-border bg-coach-bg px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary';
+
+const LIFE_POSITIONS: LifePosition[] = ['I_OK_YOU_OK', 'I_OK_YOU_NOT_OK', 'I_NOT_OK_YOU_OK', 'I_NOT_OK_YOU_NOT_OK'];
+
+const asString = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+/** Strips common markdown markup (headers, bold/italic, list bullets, inline code) so AI-generated
+ * text (e.g. the session summary) can seed a plain-text form field without literal `**`/`#` noise. */
+export const stripMarkdown = (text: string): string =>
+  text
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/^[-*]\s+/gm, '')
+    .replace(/`(.+?)`/g, '$1')
+    .trim();
+
+/**
+ * Shared create/edit form for a saved framework entry — reused by InsightCatcherPanel (creating
+ * one mid-chat) and SavedFrameworkEntryCard (editing one on "Đúc kết"). Renders different fields
+ * per frameworkType; LIFE_POSITIONS additionally requires picking an existing person (relationship
+ * map) since it's always about one specific relationship.
+ */
+const FrameworkEntryForm = ({
+  frameworkType,
+  initialTitle,
+  initialPayload,
+  initialPersonId,
+  onSubmit,
+  onCancel,
+  submitLabel,
+}: FrameworkEntryFormProps) => {
+  const { t } = useTranslation();
+  const { data: people } = usePeopleQuery();
+
+  const [title, setTitle] = useState(initialTitle ?? '');
+
+  // FREEFORM
+  const [content, setContent] = useState(asString(initialPayload?.content));
+  const [tagsInput, setTagsInput] = useState(
+    Array.isArray(initialPayload?.tags) ? (initialPayload!.tags as string[]).join(', ') : '',
+  );
+
+  // JOHARI_WINDOW
+  const [open, setOpen] = useState(asString(initialPayload?.open));
+  const [blind, setBlind] = useState(asString(initialPayload?.blind));
+  const [hidden, setHidden] = useState(asString(initialPayload?.hidden));
+  const [unknown, setUnknown] = useState(asString(initialPayload?.unknown));
+
+  // ACT_MATRIX
+  const [fiveSenses, setFiveSenses] = useState(asString(initialPayload?.fiveSenses));
+  const [values, setValues] = useState(asString(initialPayload?.values));
+  const [awayMoves, setAwayMoves] = useState(asString(initialPayload?.awayMoves));
+  const [towardMoves, setTowardMoves] = useState(asString(initialPayload?.towardMoves));
+
+  // PERSONAL_SWOT
+  const [strengths, setStrengths] = useState(asString(initialPayload?.strengths));
+  const [weaknesses, setWeaknesses] = useState(asString(initialPayload?.weaknesses));
+  const [opportunities, setOpportunities] = useState(asString(initialPayload?.opportunities));
+  const [threats, setThreats] = useState(asString(initialPayload?.threats));
+
+  // LIFE_POSITIONS
+  const [personId, setPersonId] = useState(initialPersonId ?? '');
+  const [position, setPosition] = useState<LifePosition>((initialPayload?.position as LifePosition) ?? 'I_OK_YOU_OK');
+  const [notes, setNotes] = useState(asString(initialPayload?.notes));
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    let payload: Record<string, unknown>;
+    let resolvedPersonId: string | undefined;
+
+    if (frameworkType === 'FREEFORM') {
+      if (!content.trim()) {
+        setError(t('insightCatcher.freeform.contentRequired'));
+        return;
+      }
+      const tags = tagsInput.split(',').map((tag) => tag.trim()).filter(Boolean);
+      payload = { content: content.trim(), ...(tags.length > 0 ? { tags } : {}) };
+    } else if (frameworkType === 'JOHARI_WINDOW') {
+      if (!open.trim() && !blind.trim() && !hidden.trim() && !unknown.trim()) {
+        setError(t('insightCatcher.johari.atLeastOneRequired'));
+        return;
+      }
+      payload = { open: open.trim(), blind: blind.trim(), hidden: hidden.trim(), unknown: unknown.trim() };
+    } else if (frameworkType === 'ACT_MATRIX') {
+      if (!fiveSenses.trim() && !values.trim() && !awayMoves.trim() && !towardMoves.trim()) {
+        setError(t('insightCatcher.actMatrixForm.atLeastOneRequired'));
+        return;
+      }
+      payload = {
+        fiveSenses: fiveSenses.trim(),
+        values: values.trim(),
+        awayMoves: awayMoves.trim(),
+        towardMoves: towardMoves.trim(),
+      };
+    } else if (frameworkType === 'PERSONAL_SWOT') {
+      if (!strengths.trim() && !weaknesses.trim() && !opportunities.trim() && !threats.trim()) {
+        setError(t('insightCatcher.swotForm.atLeastOneRequired'));
+        return;
+      }
+      payload = {
+        strengths: strengths.trim(),
+        weaknesses: weaknesses.trim(),
+        opportunities: opportunities.trim(),
+        threats: threats.trim(),
+      };
+    } else {
+      // LIFE_POSITIONS
+      if (!personId) {
+        setError(t('insightCatcher.lifePositionsForm.personRequired'));
+        return;
+      }
+      payload = { position, notes: notes.trim() };
+      resolvedPersonId = personId;
+    }
+
+    setError(null);
+    setSaving(true);
+    try {
+      await onSubmit(title.trim() || undefined, payload, resolvedPersonId);
+    } catch {
+      setError(t('insightCatcher.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {frameworkType === 'LIFE_POSITIONS' ? (
+        <>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-coach-text-muted">
+              {t('insightCatcher.lifePositionsForm.person')}
+            </label>
+            {people && people.length > 0 ? (
+              <select value={personId} onChange={(e) => setPersonId(e.target.value)} className={FIELD_CLASSES}>
+                <option value="">{t('insightCatcher.lifePositionsForm.personPlaceholder')}</option>
+                {people.map((person) => (
+                  <option key={person.id} value={person.id}>
+                    {person.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <p className="text-xs text-coach-text-muted">{t('insightCatcher.lifePositionsForm.noPeople')}</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-coach-text-muted">
+              {t('insightCatcher.lifePositionsForm.position')}
+            </label>
+            <select
+              value={position}
+              onChange={(e) => setPosition(e.target.value as LifePosition)}
+              className={FIELD_CLASSES}
+            >
+              {LIFE_POSITIONS.map((pos) => (
+                <option key={pos} value={pos}>
+                  {t(`insightCatcher.lifePositionsForm.positions.${pos}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder={t('insightCatcher.lifePositionsForm.notesPlaceholder') as string}
+            rows={3}
+            className={FIELD_CLASSES}
+          />
+        </>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={t('insightCatcher.titlePlaceholder') as string}
+            className={FIELD_CLASSES}
+          />
+
+          {frameworkType === 'FREEFORM' && (
+            <>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder={t('insightCatcher.freeform.contentPlaceholder') as string}
+                rows={4}
+                className={FIELD_CLASSES}
+              />
+              <input
+                type="text"
+                value={tagsInput}
+                onChange={(e) => setTagsInput(e.target.value)}
+                placeholder={t('insightCatcher.freeform.tagsPlaceholder') as string}
+                className={FIELD_CLASSES}
+              />
+            </>
+          )}
+
+          {frameworkType === 'JOHARI_WINDOW' && (
+            <>
+              <FormField label={t('insightCatcher.johari.open')} value={open} onChange={setOpen} />
+              <FormField label={t('insightCatcher.johari.blind')} value={blind} onChange={setBlind} />
+              <FormField label={t('insightCatcher.johari.hidden')} value={hidden} onChange={setHidden} />
+              <FormField label={t('insightCatcher.johari.unknown')} value={unknown} onChange={setUnknown} />
+            </>
+          )}
+
+          {frameworkType === 'ACT_MATRIX' && (
+            <>
+              <FormField label={t('insightCatcher.actMatrixForm.fiveSenses')} value={fiveSenses} onChange={setFiveSenses} />
+              <FormField label={t('insightCatcher.actMatrixForm.values')} value={values} onChange={setValues} />
+              <FormField label={t('insightCatcher.actMatrixForm.awayMoves')} value={awayMoves} onChange={setAwayMoves} />
+              <FormField label={t('insightCatcher.actMatrixForm.towardMoves')} value={towardMoves} onChange={setTowardMoves} />
+            </>
+          )}
+
+          {frameworkType === 'PERSONAL_SWOT' && (
+            <>
+              <FormField label={t('insightCatcher.swotForm.strengths')} value={strengths} onChange={setStrengths} />
+              <FormField label={t('insightCatcher.swotForm.weaknesses')} value={weaknesses} onChange={setWeaknesses} />
+              <FormField label={t('insightCatcher.swotForm.opportunities')} value={opportunities} onChange={setOpportunities} />
+              <FormField label={t('insightCatcher.swotForm.threats')} value={threats} onChange={setThreats} />
+            </>
+          )}
+        </>
+      )}
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      <div className="flex gap-2">
+        <Button variant="primary" size="sm" onClick={handleSubmit} disabled={saving}>
+          {saving ? t('insightCatcher.saving') : submitLabel}
+        </Button>
+        <Button variant="secondary" size="sm" onClick={onCancel} disabled={saving}>
+          {t('insightCatcher.cancel')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const FormField = ({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) => (
+  <div className="flex flex-col gap-1">
+    <label className="text-xs font-medium text-coach-text-muted">{label}</label>
+    <textarea value={value} onChange={(e) => onChange(e.target.value)} rows={2} className={FIELD_CLASSES} />
+  </div>
+);
+
+export default FrameworkEntryForm;

--- a/src/components/InsightCatcher/InsightCatcherPanel.tsx
+++ b/src/components/InsightCatcher/InsightCatcherPanel.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LuBookOpen, LuCompass, LuGrid2X2, LuScale, LuUserPlus, LuUsers } from 'react-icons/lu';
+import FrameworkEntryForm, { stripMarkdown } from './FrameworkEntryForm';
+import PersonForm from '../PersonForm/PersonForm';
+import { useCreateSavedFrameworkEntryMutation } from '../../queries/savedFrameworkEntriesQueryHook';
+import { useCreatePersonMutation } from '../../queries/peopleQueryHook';
+import type { FrameworkType } from '../../models/savedFrameworkEntry';
+import type { CreatePersonRequest } from '../../models/person';
+
+interface InsightCatcherPanelProps {
+  conversationId: string | null;
+  /** Latest "Tóm tắt" text, if any — seeds the Free-form content field so the connection between
+   * summarizing and saving is shown, not just explained (see plan doc, Phase 2b). */
+  latestSummary?: string | null;
+  /** A SavedFrameworkEntry (self insight or Life Positions) was saved — redirect to Đúc kết. */
+  onSaved: (entryId: string) => void;
+  /** A Person was added/updated via the PRM quick-add flow — redirect to "Thấu hiểu". */
+  onPersonSaved: (personId: string) => void;
+}
+
+interface FrameworkOption {
+  type: FrameworkType;
+  labelKey: string;
+  descKey: string;
+  icon: typeof LuBookOpen;
+}
+
+const SELF_FRAMEWORK_OPTIONS: FrameworkOption[] = [
+  { type: 'FREEFORM', labelKey: 'insightCatcher.freeformLabel', descKey: 'insightCatcher.freeformDesc', icon: LuBookOpen },
+  { type: 'JOHARI_WINDOW', labelKey: 'insightCatcher.johariWindowLabel', descKey: 'insightCatcher.johariWindowDesc', icon: LuGrid2X2 },
+  { type: 'ACT_MATRIX', labelKey: 'insightCatcher.actMatrix', descKey: 'insightCatcher.actMatrixDesc', icon: LuCompass },
+  { type: 'PERSONAL_SWOT', labelKey: 'insightCatcher.personalSwot', descKey: 'insightCatcher.personalSwotDesc', icon: LuScale },
+];
+
+/**
+ * Right-hand "catch an insight" column on the Aura chat page. Two groups, matching the user's
+ * original split: "về bản thân" (self — Free-form/Johari/ACT Matrix/SWOT, saved as
+ * SavedFrameworkEntry, shown on "Đúc kết") and "Bản đồ mối quan hệ (PRM)" (relationship — Life
+ * Positions, also a SavedFrameworkEntry but tied to a Person; and the PRM quick-add/update-Person
+ * flow, shown on "Thấu hiểu"). Each option is a labeled card with a one-line description — plain
+ * icon+label buttons tested as unexplained jargon to anyone unfamiliar with these frameworks.
+ */
+const InsightCatcherPanel = ({ conversationId, latestSummary, onSaved, onPersonSaved }: InsightCatcherPanelProps) => {
+  const { t } = useTranslation();
+  const [activeFramework, setActiveFramework] = useState<FrameworkType | null>(null);
+  const [isAddingPerson, setIsAddingPerson] = useState(false);
+  const createEntry = useCreateSavedFrameworkEntryMutation();
+  const createPerson = useCreatePersonMutation();
+
+  const handleSubmitEntry = async (title: string | undefined, payload: Record<string, unknown>, personId?: string) => {
+    if (!activeFramework) return;
+    const entry = await createEntry.mutateAsync({
+      frameworkType: activeFramework,
+      title,
+      payload,
+      conversationId: conversationId ?? undefined,
+      personId,
+    });
+    setActiveFramework(null);
+    onSaved(entry.id);
+  };
+
+  const handleAddPerson = async (person: CreatePersonRequest) => {
+    const saved = await createPerson.mutateAsync(person);
+    setIsAddingPerson(false);
+    onPersonSaved(saved.id);
+  };
+
+  if (activeFramework) {
+    // Seed Free-form with the latest summary so "log theo format nào" has a concrete answer:
+    // the summary itself becomes the starting content, editable before saving.
+    const initialPayload =
+      activeFramework === 'FREEFORM' && latestSummary ? { content: stripMarkdown(latestSummary) } : undefined;
+
+    return (
+      <div className="flex h-full flex-col gap-3 p-4">
+        <h2 className="text-sm font-semibold text-coach-text">{t(labelKeyFor(activeFramework))}</h2>
+        <FrameworkEntryForm
+          frameworkType={activeFramework}
+          initialPayload={initialPayload}
+          onSubmit={handleSubmitEntry}
+          onCancel={() => setActiveFramework(null)}
+          submitLabel={t('insightCatcher.save')}
+        />
+      </div>
+    );
+  }
+
+  if (isAddingPerson) {
+    return (
+      <div className="flex h-full flex-col gap-3 p-4">
+        <h2 className="text-sm font-semibold text-coach-text">{t('insightCatcher.prm')}</h2>
+        <PersonForm onSubmit={handleAddPerson} onCancel={() => setIsAddingPerson(false)} submitLabel={t('insightCatcher.save')} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-4">
+      <div>
+        <h2 className="text-sm font-semibold text-coach-text">{t('insightCatcher.title')}</h2>
+        <p className="mt-1 text-xs text-coach-text-muted">{t('insightCatcher.subtitle')}</p>
+        <div className="mt-2 flex flex-col gap-2">
+          {SELF_FRAMEWORK_OPTIONS.map((option) => (
+            <FrameworkOptionCard key={option.type} option={option} onClick={() => setActiveFramework(option.type)} />
+          ))}
+        </div>
+      </div>
+
+      <div className="border-t border-coach-border pt-3">
+        <h2 className="text-sm font-semibold text-coach-text">{t('insightCatcher.relationshipTitle')}</h2>
+        <p className="mt-1 text-xs text-coach-text-muted">{t('insightCatcher.relationshipSubtitle')}</p>
+        <div className="mt-2 flex flex-col gap-2">
+          <FrameworkOptionCard
+            option={{
+              type: 'LIFE_POSITIONS',
+              labelKey: 'insightCatcher.lifePositions',
+              descKey: 'insightCatcher.lifePositionsDesc',
+              icon: LuUsers,
+            }}
+            onClick={() => setActiveFramework('LIFE_POSITIONS')}
+          />
+          <button
+            type="button"
+            onClick={() => setIsAddingPerson(true)}
+            className="flex flex-col items-start gap-0.5 rounded-lg border border-coach-border bg-coach-bg px-3 py-2.5 text-left transition-colors hover:border-coach-primary hover:bg-coach-surface"
+          >
+            <span className="flex items-center gap-2 text-sm font-medium text-coach-text">
+              <LuUserPlus size={14} className="text-coach-primary" />
+              {t('insightCatcher.prm')}
+            </span>
+            <span className="text-xs text-coach-text-muted">{t('insightCatcher.prmDesc')}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const FrameworkOptionCard = ({ option, onClick }: { option: FrameworkOption; onClick: () => void }) => {
+  const { t } = useTranslation();
+  const Icon = option.icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-start gap-0.5 rounded-lg border border-coach-border bg-coach-bg px-3 py-2.5 text-left transition-colors hover:border-coach-primary hover:bg-coach-surface"
+    >
+      <span className="flex items-center gap-2 text-sm font-medium text-coach-text">
+        <Icon size={14} className="text-coach-primary" />
+        {t(option.labelKey)}
+      </span>
+      <span className="text-xs text-coach-text-muted">{t(option.descKey)}</span>
+    </button>
+  );
+};
+
+const labelKeyFor = (type: FrameworkType): string => {
+  switch (type) {
+    case 'FREEFORM':
+      return 'insightCatcher.freeformLabel';
+    case 'JOHARI_WINDOW':
+      return 'insightCatcher.johariWindowLabel';
+    case 'ACT_MATRIX':
+      return 'insightCatcher.actMatrix';
+    case 'PERSONAL_SWOT':
+      return 'insightCatcher.personalSwot';
+    case 'LIFE_POSITIONS':
+      return 'insightCatcher.lifePositions';
+    default:
+      return 'insightCatcher.title';
+  }
+};
+
+export default InsightCatcherPanel;

--- a/src/components/InsightTimeline/InsightCard.tsx
+++ b/src/components/InsightTimeline/InsightCard.tsx
@@ -28,6 +28,11 @@ const InsightCard = ({ insight }: InsightCardProps) => {
         <span className="text-xs text-coach-text-muted">{dateLabel}</span>
       </div>
       <p className="text-sm text-coach-text">{insight.insightText}</p>
+      {insight.personName && (
+        <p className="mt-1.5 text-xs text-coach-primary">
+          {t('dashboard.person.relatedTo', { name: insight.personName })}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/components/PersonForm/PersonForm.tsx
+++ b/src/components/PersonForm/PersonForm.tsx
@@ -42,26 +42,27 @@ const PersonForm = ({ initialValue, onSubmit, onCancel, submitLabel }: PersonFor
 
   return (
     <div className="flex flex-col gap-2 rounded-xl border border-coach-border bg-coach-bg p-3">
-      <div className="flex items-center gap-2">
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder={t('onboarding.namePlaceholder')}
-          className="flex-1 rounded-lg border border-coach-border bg-coach-surface px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
-        />
-        <select
-          value={relationshipType}
-          onChange={(e) => setRelationshipType(e.target.value as RelationshipType)}
-          className="rounded-lg border border-coach-border bg-coach-surface px-2 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
-        >
-          {RELATIONSHIP_TYPES.map((type) => (
-            <option key={type} value={type}>
-              {t(`onboarding.relationshipType.${type}`)}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* Stacked, not side-by-side: a fixed-width select next to a flex-1 input overflows in
+          narrow containers (e.g. the 320px Insight Catcher panel) since neither shrinks below
+          its content's intrinsic width by default. */}
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder={t('onboarding.namePlaceholder')}
+        className="w-full min-w-0 rounded-lg border border-coach-border bg-coach-surface px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
+      />
+      <select
+        value={relationshipType}
+        onChange={(e) => setRelationshipType(e.target.value as RelationshipType)}
+        className="w-full min-w-0 rounded-lg border border-coach-border bg-coach-surface px-2 py-2 text-sm text-coach-text outline-none focus:border-coach-primary"
+      >
+        {RELATIONSHIP_TYPES.map((type) => (
+          <option key={type} value={type}>
+            {t(`onboarding.relationshipType.${type}`)}
+          </option>
+        ))}
+      </select>
       <textarea
         value={notes}
         onChange={(e) => setNotes(e.target.value)}

--- a/src/components/RelationshipMap/RelationshipMap.tsx
+++ b/src/components/RelationshipMap/RelationshipMap.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Person } from '../../models/person';
 import { useUpdatePersonMutation } from '../../queries/peopleQueryHook';
+import { usePersonInsightsQuery } from '../../queries/insightsQueryHook';
 import PersonForm from '../PersonForm/PersonForm';
 
 interface RelationshipMapProps {
@@ -55,6 +56,7 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
   }, [people]);
 
   const selected = people.find((p) => p.id === selectedId) ?? null;
+  const { data: personInsights } = usePersonInsightsQuery(selected?.id ?? null);
 
   if (people.length === 0) {
     return (
@@ -156,6 +158,21 @@ const RelationshipMap = ({ people, emptyLabel }: RelationshipMapProps) => {
             <p className="mt-1 text-coach-text-muted">
               {t('dashboard.noNudge')}
             </p>
+          )}
+
+          {personInsights && personInsights.content.length > 0 && (
+            <div className="mt-3 border-t border-coach-border pt-2">
+              <p className="text-xs font-semibold tracking-wide text-coach-text-muted uppercase">
+                {t('dashboard.person.relatedInsights')}
+              </p>
+              <ul className="mt-1 flex flex-col gap-1">
+                {personInsights.content.map((insight) => (
+                  <li key={insight.id} className="text-xs text-coach-text-muted">
+                    {insight.insightText}
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
         </div>
       )}

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -15,5 +15,7 @@ export const APP_ROUTES = {
     // Coach / Relationship Map pivot
     ONBOARDING: '/onboarding',
     COACH_CHAT: '/coach',
+    COACH_HISTORY: '/coach/history',
+    COACH_HISTORY_DETAIL: '/coach/history/:id',
     DASHBOARD: '/dashboard',
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -47,7 +47,92 @@
     "send": "Send",
     "endSession": "End session",
     "emptyState": "Feel free to start — share whatever's on your mind right now. I'm here to listen.",
-    "sendError": "Couldn't send your message right now. Please try again."
+    "sendError": "Couldn't send your message right now. Please try again.",
+    "summarize": "Summarize",
+    "summarizing": "Summarizing...",
+    "summarizeError": "Couldn't summarize right now. Please try again.",
+    "summarizeNudge": "💡 Want to save this? Pick a format on the right.",
+    "historyLink": "Chat history",
+    "history": {
+      "title": "Chat history",
+      "empty": "No sessions yet.",
+      "noSummary": "No summary for this session yet.",
+      "statusActive": "In progress",
+      "statusEnded": "Ended",
+      "statusExtracting": "Processing",
+      "back": "Back",
+      "backToChat": "New chat",
+      "sessionTitle": "Session details",
+      "summaryLabel": "Summary",
+      "loadError": "Couldn't load this session."
+    }
+  },
+  "insightCatcher": {
+    "title": "Capture an insight",
+    "subtitle": "Pick a framework to save what you just realized.",
+    "freeformLabel": "Free-form log",
+    "freeformDesc": "Write down a thought your own way — no template needed.",
+    "johariWindowLabel": "Johari Window",
+    "johariWindowDesc": "Separate what you already know from what others see but you don't.",
+    "actMatrix": "ACT Matrix",
+    "actMatrixDesc": "Spot what you're avoiding and the actions that actually match your values.",
+    "personalSwot": "Personal SWOT",
+    "personalSwotDesc": "See your strengths, weaknesses, opportunities, and threats clearly.",
+    "lifePositions": "Life Positions",
+    "lifePositionsDesc": "Assess where you stand in one specific relationship (the OK Corral model).",
+    "titlePlaceholder": "Title (optional)",
+    "save": "Save",
+    "saveChanges": "Save changes",
+    "saving": "Saving...",
+    "saveError": "Couldn't save right now. Please try again.",
+    "updateSuccess": "Updated.",
+    "cancel": "Cancel",
+    "edit": "Edit",
+    "freeform": {
+      "contentPlaceholder": "What did you just realize?",
+      "tagsPlaceholder": "Tags, comma-separated (optional)",
+      "contentRequired": "Please enter some content."
+    },
+    "johari": {
+      "open": "Open — Both you and others know",
+      "blind": "Blind spot — Others know, you don't",
+      "hidden": "Hidden — You know, others don't",
+      "unknown": "Unknown — Neither of you knows yet",
+      "atLeastOneRequired": "Please fill in at least one box."
+    },
+    "relationshipTitle": "Relationship Map (PRM)",
+    "relationshipSubtitle": "Capture an insight about a specific relationship, or update that person on the map.",
+    "prm": "Add / update in PRM",
+    "prmDesc": "Add or update a person in your Relationship Map (PRM).",
+    "actMatrixForm": {
+      "atLeastOneRequired": "Please fill in at least one box.",
+      "fiveSenses": "5 senses — Who/what was around you then?",
+      "values": "What matters to me",
+      "awayMoves": "Avoidance behavior",
+      "towardMoves": "Values-based action"
+    },
+    "swotForm": {
+      "atLeastOneRequired": "Please fill in at least one box.",
+      "strengths": "Strengths",
+      "weaknesses": "Weaknesses",
+      "opportunities": "Opportunities",
+      "threats": "Threats"
+    },
+    "lifePositionsForm": {
+      "personRequired": "Please select who this is about.",
+      "person": "About whom?",
+      "personPlaceholder": "Choose a person from your relationship map",
+      "noPeople": "No one on the map yet — add a person first via 'Add / update in PRM'.",
+      "position": "Position",
+      "notesPlaceholder": "Notes (optional)",
+      "about": "About {{name}}",
+      "positions": {
+        "I_OK_YOU_OK": "I'm OK — You're OK",
+        "I_OK_YOU_NOT_OK": "I'm OK — You're not OK",
+        "I_NOT_OK_YOU_OK": "I'm not OK — You're OK",
+        "I_NOT_OK_YOU_NOT_OK": "I'm not OK — You're not OK"
+      }
+    }
   },
   "homePreview": {
     "pillars": {
@@ -321,7 +406,9 @@
       "cancel": "Cancel",
       "nameRequired": "Enter a name first.",
       "saveError": "Something went wrong, please try again.",
-      "notesPlaceholder": "Notes (optional)"
+      "notesPlaceholder": "Notes (optional)",
+      "relatedInsights": "Related insights",
+      "relatedTo": "Related to {{name}}"
     }
   },
   "profilePage": {
@@ -468,7 +555,12 @@
     "updateSuccess": "Your reflection has been updated.",
     "updateError": "Failed to update reflection.",
     "deleteSuccess": "Reflection deleted.",
-    "deleteError": "Failed to delete reflection."
+    "deleteError": "Failed to delete reflection.",
+    "tabEntries": "Journal",
+    "tabInsights": "Saved insights",
+    "insightsEmpty": "No saved insights yet.",
+    "insightsEmptyHint": "Chat with Aura and save an insight to see it here.",
+    "goChatWithAura": "Chat with Aura"
   },
   "actionProtocol": {
     "list": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -47,7 +47,92 @@
     "send": "Gửi",
     "endSession": "Kết thúc phiên",
     "emptyState": "Bạn cứ thoải mái bắt đầu — chia sẻ điều đang ở trong đầu bạn lúc này, mình ở đây để lắng nghe.",
-    "sendError": "Không thể gửi tin nhắn lúc này. Vui lòng thử lại."
+    "sendError": "Không thể gửi tin nhắn lúc này. Vui lòng thử lại.",
+    "summarize": "Tóm tắt",
+    "summarizing": "Đang tóm tắt...",
+    "summarizeError": "Không thể tóm tắt lúc này. Vui lòng thử lại.",
+    "summarizeNudge": "💡 Muốn lưu lại? Chọn một định dạng ở bảng bên phải.",
+    "historyLink": "Lịch sử trò chuyện",
+    "history": {
+      "title": "Lịch sử trò chuyện",
+      "empty": "Chưa có phiên trò chuyện nào.",
+      "noSummary": "Chưa có tóm tắt cho phiên này.",
+      "statusActive": "Đang diễn ra",
+      "statusEnded": "Đã kết thúc",
+      "statusExtracting": "Đang xử lý",
+      "back": "Quay lại",
+      "backToChat": "Trò chuyện mới",
+      "sessionTitle": "Chi tiết phiên",
+      "summaryLabel": "Tóm tắt",
+      "loadError": "Không thể tải phiên trò chuyện này."
+    }
+  },
+  "insightCatcher": {
+    "title": "Ghi lại insight",
+    "subtitle": "Chọn một khung tư duy để lưu lại điều bạn vừa nhận ra.",
+    "freeformLabel": "Log tự do",
+    "freeformDesc": "Ghi lại một suy nghĩ theo cách của riêng bạn — không cần khuôn mẫu.",
+    "johariWindowLabel": "Cửa sổ Johari",
+    "johariWindowDesc": "Phân biệt điều bạn đã biết, điều người khác thấy mà bạn chưa nhận ra.",
+    "actMatrix": "ACT Matrix",
+    "actMatrixDesc": "Nhận diện điều bạn đang né tránh và hành động thực sự phù hợp với giá trị của bạn.",
+    "personalSwot": "SWOT Cá Nhân",
+    "personalSwotDesc": "Nhìn rõ điểm mạnh, điểm yếu, cơ hội và thách thức của bản thân.",
+    "lifePositions": "Life Positions",
+    "lifePositionsDesc": "Đánh giá vị thế của bạn trong một mối quan hệ cụ thể (mô hình OK Corral).",
+    "titlePlaceholder": "Tiêu đề (không bắt buộc)",
+    "save": "Lưu",
+    "saveChanges": "Lưu thay đổi",
+    "saving": "Đang lưu...",
+    "saveError": "Không thể lưu lúc này. Vui lòng thử lại.",
+    "updateSuccess": "Đã cập nhật.",
+    "cancel": "Huỷ",
+    "edit": "Sửa",
+    "freeform": {
+      "contentPlaceholder": "Bạn vừa nhận ra điều gì?",
+      "tagsPlaceholder": "Thẻ, cách nhau bởi dấu phẩy (không bắt buộc)",
+      "contentRequired": "Vui lòng nhập nội dung."
+    },
+    "johari": {
+      "open": "Open — Bản thân & người khác đều biết",
+      "blind": "Blind spot — Người khác biết, bản thân không biết",
+      "hidden": "Hidden — Bản thân biết, người khác không biết",
+      "unknown": "Unknown — Cả hai đều chưa biết",
+      "atLeastOneRequired": "Vui lòng điền ít nhất một ô."
+    },
+    "relationshipTitle": "Bản đồ mối quan hệ (PRM)",
+    "relationshipSubtitle": "Ghi lại insight về một mối quan hệ cụ thể, hoặc cập nhật người đó vào bản đồ.",
+    "prm": "Thêm / cập nhật vào PRM",
+    "prmDesc": "Thêm hoặc cập nhật một người vào Bản đồ mối quan hệ (PRM) của bạn.",
+    "actMatrixForm": {
+      "atLeastOneRequired": "Vui lòng điền ít nhất một ô.",
+      "fiveSenses": "5 giác quan — Ai/điều gì xung quanh bạn lúc đó?",
+      "values": "Điều quan trọng với tôi",
+      "awayMoves": "Hành vi né tránh",
+      "towardMoves": "Hành động hướng tới giá trị"
+    },
+    "swotForm": {
+      "atLeastOneRequired": "Vui lòng điền ít nhất một ô.",
+      "strengths": "Điểm mạnh",
+      "weaknesses": "Điểm yếu",
+      "opportunities": "Cơ hội",
+      "threats": "Thách thức"
+    },
+    "lifePositionsForm": {
+      "personRequired": "Vui lòng chọn người liên quan.",
+      "person": "Về ai?",
+      "personPlaceholder": "Chọn một người trong bản đồ mối quan hệ",
+      "noPeople": "Chưa có ai trong bản đồ — hãy thêm người trước qua nút 'Thêm / cập nhật vào PRM'.",
+      "position": "Vị thế",
+      "notesPlaceholder": "Ghi chú (tuỳ chọn)",
+      "about": "Về {{name}}",
+      "positions": {
+        "I_OK_YOU_OK": "Tôi ổn — Bạn cũng ổn",
+        "I_OK_YOU_NOT_OK": "Tôi ổn — Bạn không ổn",
+        "I_NOT_OK_YOU_OK": "Tôi không ổn — Bạn ổn",
+        "I_NOT_OK_YOU_NOT_OK": "Tôi không ổn — Bạn cũng không ổn"
+      }
+    }
   },
   "homePreview": {
     "pillars": {
@@ -321,7 +406,9 @@
       "cancel": "Hủy",
       "nameRequired": "Nhập tên trước đã.",
       "saveError": "Có lỗi xảy ra, vui lòng thử lại.",
-      "notesPlaceholder": "Ghi chú (tuỳ chọn)"
+      "notesPlaceholder": "Ghi chú (tuỳ chọn)",
+      "relatedInsights": "Insight liên quan",
+      "relatedTo": "Liên quan đến {{name}}"
     }
   },
   "profilePage": {
@@ -468,7 +555,12 @@
     "updateSuccess": "Đúc kết đã được cập nhật.",
     "updateError": "Không thể cập nhật đúc kết.",
     "deleteSuccess": "Đã xóa đúc kết.",
-    "deleteError": "Không thể xóa đúc kết."
+    "deleteError": "Không thể xóa đúc kết.",
+    "tabEntries": "Nhật ký",
+    "tabInsights": "Insight đã lưu",
+    "insightsEmpty": "Chưa có insight nào được lưu.",
+    "insightsEmptyHint": "Trò chuyện với Aura và lưu lại insight để xem tại đây.",
+    "goChatWithAura": "Trò chuyện với Aura"
   },
   "actionProtocol": {
     "list": {

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -15,4 +15,7 @@ export interface Conversation {
   startedAt: string;
   endedAt?: string;
   messages: ConversationMessage[];
+
+  /** AI-generated markdown recap, present once the user has requested a summary at least once. */
+  summary?: string;
 }

--- a/src/models/insight.ts
+++ b/src/models/insight.ts
@@ -5,4 +5,7 @@ export interface Insight {
   insightText: string;
   category: InsightCategory;
   createdAt: string;
+  /** Which person (relationship map) this insight is about, if the extraction could tell. */
+  personId?: string;
+  personName?: string;
 }

--- a/src/models/savedFrameworkEntry.ts
+++ b/src/models/savedFrameworkEntry.ts
@@ -1,0 +1,72 @@
+/**
+ * A user-authored, editable structured entry captured from (or inspired by) an Aura chat —
+ * shown and editable on "Đúc kết". Deliberately separate from `Insight` (models/insight.ts,
+ * if present) — that's the AI auto-extracted, read-only timeline shown on "Thấu hiểu". This is
+ * the opposite: user-owned and editable.
+ *
+ * Only FREEFORM and JOHARI_WINDOW are reachable via the UI today — the rest are reserved for a
+ * later phase (see plan doc) so adding them won't require touching the type shape below.
+ */
+export type FrameworkType = 'FREEFORM' | 'JOHARI_WINDOW' | 'ACT_MATRIX' | 'PERSONAL_SWOT' | 'LIFE_POSITIONS';
+
+export interface FreeformPayload {
+  content: string;
+  tags?: string[];
+}
+
+export interface JohariWindowPayload {
+  open: string;
+  blind: string;
+  hidden: string;
+  unknown: string;
+}
+
+export interface ActMatrixPayload {
+  fiveSenses: string;
+  values: string;
+  awayMoves: string;
+  towardMoves: string;
+}
+
+export interface PersonalSwotPayload {
+  strengths: string;
+  weaknesses: string;
+  opportunities: string;
+  threats: string;
+}
+
+/** Transactional-analysis "OK Corral" positions — always about one specific relationship. */
+export type LifePosition = 'I_OK_YOU_OK' | 'I_OK_YOU_NOT_OK' | 'I_NOT_OK_YOU_OK' | 'I_NOT_OK_YOU_NOT_OK';
+
+export interface LifePositionsPayload {
+  position: LifePosition;
+  notes?: string;
+}
+
+export interface SavedFrameworkEntry {
+  id: string;
+  frameworkType: FrameworkType;
+  title?: string;
+  payload: Record<string, unknown>;
+  conversationId?: string;
+  /** Which person (relationship map) this entry is about — set for LIFE_POSITIONS. */
+  personId?: string;
+  personName?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSavedFrameworkEntryRequest {
+  frameworkType: FrameworkType;
+  title?: string;
+  payload: Record<string, unknown>;
+  conversationId?: string;
+  personId?: string;
+}
+
+export interface UpdateSavedFrameworkEntryRequest {
+  id: string;
+  title?: string;
+  payload: Record<string, unknown>;
+  personId?: string;
+}

--- a/src/pages/CoachChatPage/CoachChatPage.tsx
+++ b/src/pages/CoachChatPage/CoachChatPage.tsx
@@ -1,15 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { LuHistory, LuSparkles } from 'react-icons/lu';
 import MessageList from '../../components/Chat/MessageList';
 import MessageInput from '../../components/Chat/MessageInput';
 import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
 import { Button } from '../../components/Button/Button';
+import InsightCatcherPanel from '../../components/InsightCatcher/InsightCatcherPanel';
 import auraIdle from '../../assets/aura/aura-idle.gif';
 import type { ConversationMessage } from '../../models/conversation';
 import { conversationsService } from '../../services/conversationsService';
-import { useSendMessageMutation, useEndConversationMutation } from '../../queries/conversationsQueryHook';
+import {
+  useSendMessageMutation,
+  useEndConversationMutation,
+  useSummarizeConversationMutation,
+} from '../../queries/conversationsQueryHook';
 import { APP_ROUTES } from '../../constants/route';
+
+/** Survives a refresh so an in-progress session can be resumed instead of silently restarted. */
+const ACTIVE_CONVERSATION_KEY = 'aura_active_conversation_id';
 
 const CoachChatPage = () => {
   const { t } = useTranslation();
@@ -17,24 +26,48 @@ const CoachChatPage = () => {
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [isStarting, setIsStarting] = useState(true);
   const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [latestSummary, setLatestSummary] = useState<string | null>(null);
   const hasStartedRef = useRef(false);
   const lastHandledReplyIdRef = useRef<string | null>(null);
 
   const sendMessage = useSendMessageMutation(conversationId ?? '');
   const endConversation = useEndConversationMutation();
+  const summarizeConversation = useSummarizeConversationMutation();
 
   // Deliberately bypasses useMutation here: calling .mutate() synchronously from a mount
   // effect races with StrictMode's dev-only double-invoke of effects and can leave the
   // mutation observer unsubscribed (confirmed via React internals during debugging) — a plain
   // service call + local state sidesteps it. useMutation is fine below for click-triggered
-  // calls (sendMessage/endConversation), which don't hit that mount-time race.
+  // calls (sendMessage/endConversation/summarize), which don't hit that mount-time race.
+  //
+  // On mount, resume a still-ACTIVE conversation stored from a previous mount (e.g. a page
+  // refresh) instead of always starting a brand-new, empty one.
   useEffect(() => {
     if (hasStartedRef.current) return;
     hasStartedRef.current = true;
-    conversationsService
-      .startConversation()
-      .then((conversation) => setConversationId(conversation.id))
-      .finally(() => setIsStarting(false));
+
+    const resume = async () => {
+      const storedId = localStorage.getItem(ACTIVE_CONVERSATION_KEY);
+      if (storedId) {
+        try {
+          const existing = await conversationsService.getConversation(storedId);
+          if (existing.status === 'ACTIVE') {
+            setConversationId(existing.id);
+            setMessages(existing.messages);
+            return;
+          }
+        } catch {
+          // Stored id is stale or no longer accessible — fall through to starting fresh.
+        }
+        localStorage.removeItem(ACTIVE_CONVERSATION_KEY);
+      }
+
+      const conversation = await conversationsService.startConversation();
+      localStorage.setItem(ACTIVE_CONVERSATION_KEY, conversation.id);
+      setConversationId(conversation.id);
+    };
+
+    resume().finally(() => setIsStarting(false));
   }, []);
 
   useEffect(() => {
@@ -47,6 +80,7 @@ const CoachChatPage = () => {
 
   useEffect(() => {
     if (endConversation.isSuccess) {
+      localStorage.removeItem(ACTIVE_CONVERSATION_KEY);
       navigate(APP_ROUTES.DASHBOARD);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -70,56 +104,118 @@ const CoachChatPage = () => {
     endConversation.mutate(conversationId);
   };
 
+  const handleSummarize = () => {
+    if (!conversationId) return;
+    summarizeConversation.mutate(conversationId, {
+      onSuccess: (conversation) => {
+        if (!conversation.summary) return;
+        setLatestSummary(conversation.summary);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `summary-${Date.now()}`,
+            role: 'ASSISTANT',
+            content: `${conversation.summary}\n\n${t('coach.summarizeNudge')}`,
+            createdAt: new Date().toISOString(),
+          },
+        ]);
+      },
+    });
+  };
+
+  const handleInsightSaved = (entryId: string) => {
+    navigate(`${APP_ROUTES.ENTRIES_LIST}?highlight=${entryId}`);
+  };
+
+  const handlePersonSaved = () => {
+    navigate(APP_ROUTES.DASHBOARD);
+  };
+
   return (
-    <div className="mx-auto flex h-[calc(100dvh-var(--header-h,64px)-var(--footer-h,64px))] w-full max-w-2xl flex-col border-x border-coach-border bg-coach-bg">
-      <div className="border-b border-coach-border bg-coach-surface px-4 pt-3 pb-4 sm:px-6">
-        <Breadcrumb
-          variant="light"
-          items={[{ label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME }, { label: t('breadcrumb.coach') }]}
-        />
-        <div className="mt-2 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <img
-              src={auraIdle}
-              alt=""
-              aria-hidden="true"
-              className="h-10 w-10 shrink-0 rounded-full border border-coach-border bg-coach-bg object-contain p-0.5"
-            />
-            <div>
-              <h1 className="text-2xl font-bold text-coach-text [font-family:var(--font-family-heading)]">
-                {t('coach.title')}
-              </h1>
-              <p className="mt-1 text-sm text-coach-text-muted">
-                {t('coach.subtitle')}
-              </p>
+    <div className="mx-auto flex w-full max-w-5xl flex-col lg:h-[calc(100dvh-var(--header-h,64px)-var(--footer-h,64px))] lg:flex-row lg:gap-4 lg:py-4">
+      <div className="flex h-[calc(100dvh-var(--header-h,64px)-var(--footer-h,64px))] min-w-0 flex-col border-x border-coach-border bg-coach-bg lg:h-auto lg:flex-1 lg:rounded-2xl lg:border">
+        <div className="border-b border-coach-border bg-coach-surface px-4 pt-3 pb-4 sm:px-6">
+          <Breadcrumb
+            variant="light"
+            items={[{ label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME }, { label: t('breadcrumb.coach') }]}
+          />
+          <div className="mt-2 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-3">
+              <img
+                src={auraIdle}
+                alt=""
+                aria-hidden="true"
+                className="h-10 w-10 shrink-0 rounded-full border border-coach-border bg-coach-bg object-contain p-0.5"
+              />
+              <div>
+                <h1 className="text-2xl font-bold text-coach-text [font-family:var(--font-family-heading)]">
+                  {t('coach.title')}
+                </h1>
+                <p className="mt-1 text-sm text-coach-text-muted">
+                  {t('coach.subtitle')}
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate(APP_ROUTES.COACH_HISTORY)}
+                title={t('coach.historyLink') as string}
+              >
+                <LuHistory size={16} />
+              </Button>
             </div>
           </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={handleEndSession}
-            disabled={!conversationId || endConversation.isPending}
-          >
-            {t('coach.endSession')}
-          </Button>
+          <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleSummarize}
+              disabled={!conversationId || messages.length === 0 || summarizeConversation.isPending}
+            >
+              <LuSparkles size={14} />
+              <span>{summarizeConversation.isPending ? t('coach.summarizing') : t('coach.summarize')}</span>
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleEndSession}
+              disabled={!conversationId || endConversation.isPending}
+            >
+              {t('coach.endSession')}
+            </Button>
+          </div>
+          {summarizeConversation.isError && (
+            <p className="mt-1 text-right text-xs text-red-500">{t('coach.summarizeError')}</p>
+          )}
         </div>
+
+        {messages.length === 0 && !isStarting && (
+          <div className="flex flex-1 items-center justify-center px-8 text-center text-sm text-coach-text-muted">
+            {t('coach.emptyState')}
+          </div>
+        )}
+
+        {sendMessage.isError && (
+          <p className="px-4 pb-1 text-center text-xs text-red-500">
+            {t('coach.sendError')}
+          </p>
+        )}
+
+        <MessageList messages={messages} isThinking={sendMessage.isPending || isStarting} />
+
+        <MessageInput onSend={handleSend} disabled={!conversationId || sendMessage.isPending} />
       </div>
 
-      {messages.length === 0 && !isStarting && (
-        <div className="flex flex-1 items-center justify-center px-8 text-center text-sm text-coach-text-muted">
-          {t('coach.emptyState')}
-        </div>
-      )}
-
-      {sendMessage.isError && (
-        <p className="px-4 pb-1 text-center text-xs text-red-500">
-          {t('coach.sendError')}
-        </p>
-      )}
-
-      <MessageList messages={messages} isThinking={sendMessage.isPending || isStarting} />
-
-      <MessageInput onSend={handleSend} disabled={!conversationId || sendMessage.isPending} />
+      <div className="w-full shrink-0 border-t border-coach-border bg-coach-surface lg:h-auto lg:w-80 lg:overflow-y-auto lg:rounded-2xl lg:border lg:border-t lg:border-coach-border">
+        <InsightCatcherPanel
+          conversationId={conversationId}
+          latestSummary={latestSummary}
+          onSaved={handleInsightSaved}
+          onPersonSaved={handlePersonSaved}
+        />
+      </div>
     </div>
   );
 };

--- a/src/pages/CoachHistoryPage/CoachHistoryDetailPage.tsx
+++ b/src/pages/CoachHistoryPage/CoachHistoryDetailPage.tsx
@@ -1,0 +1,72 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { CircularProgress } from '@mui/material';
+import { LuArrowLeft } from 'react-icons/lu';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../components/Button/Button';
+import MessageList from '../../components/Chat/MessageList';
+import { useConversationQuery } from '../../queries/conversationsQueryHook';
+import { APP_ROUTES } from '../../constants/route';
+
+/** Read-only transcript view for a past Aura chat session. */
+const CoachHistoryDetailPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const { data: conversation, isLoading, isError } = useConversationQuery(id);
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col px-4 py-6 sm:px-6">
+      <Breadcrumb
+        variant="dark"
+        items={[
+          { label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME },
+          { label: t('breadcrumb.coach'), path: APP_ROUTES.COACH_CHAT },
+          { label: t('coach.history.title'), path: APP_ROUTES.COACH_HISTORY },
+          { label: t('coach.history.sessionTitle') },
+        ]}
+      />
+
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <Button variant="ghost" size="sm" onClick={() => navigate(APP_ROUTES.COACH_HISTORY)}>
+          <LuArrowLeft size={14} />
+          <span>{t('coach.history.back')}</span>
+        </Button>
+        <Button variant="secondary" size="sm" onClick={() => navigate(APP_ROUTES.COACH_CHAT)}>
+          {t('coach.history.backToChat')}
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="flex justify-center py-10">
+          <CircularProgress size={24} />
+        </div>
+      )}
+
+      {isError && <p className="mt-8 text-center text-sm text-red-500">{t('coach.history.loadError')}</p>}
+
+      {conversation && (
+        <>
+          {conversation.summary && (
+            <div className="mt-4 rounded-xl border border-coach-border bg-coach-surface p-4">
+              <h2 className="text-xs font-semibold tracking-wide text-coach-text-muted uppercase">
+                {t('coach.history.summaryLabel')}
+              </h2>
+              <div className="mt-2 text-sm text-coach-text">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{conversation.summary}</ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          <div className="mt-4 flex-1 rounded-xl border border-coach-border bg-coach-bg">
+            <MessageList messages={conversation.messages} isThinking={false} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CoachHistoryDetailPage;

--- a/src/pages/CoachHistoryPage/CoachHistoryListPage.tsx
+++ b/src/pages/CoachHistoryPage/CoachHistoryListPage.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { CircularProgress } from '@mui/material';
+import { LuMessageCircle } from 'react-icons/lu';
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import { Button } from '../../components/Button/Button';
+import { useConversationsInfiniteQuery } from '../../queries/conversationsQueryHook';
+import { APP_ROUTES } from '../../constants/route';
+import type { ConversationStatus } from '../../models/conversation';
+
+const STATUS_LABEL_KEY: Record<ConversationStatus, string> = {
+  ACTIVE: 'coach.history.statusActive',
+  ENDED: 'coach.history.statusEnded',
+  EXTRACTING: 'coach.history.statusExtracting',
+  EXTRACTED: 'coach.history.statusEnded',
+  EXTRACTION_FAILED: 'coach.history.statusEnded',
+};
+
+/** Read-only list of past Aura chat sessions — reachable now that transcripts aren't purged
+ * after a session ends (see [[project-mimose-pivot]] purge-after-extraction default flip). */
+const CoachHistoryListPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useConversationsInfiniteQuery();
+
+  const conversations = useMemo(() => data?.pages.flatMap((page) => page.content) || [], [data]);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-6 sm:px-6">
+      <Breadcrumb
+        variant="dark"
+        items={[
+          { label: t('breadcrumb.home'), path: APP_ROUTES.WELCOME },
+          { label: t('breadcrumb.coach'), path: APP_ROUTES.COACH_CHAT },
+          { label: t('coach.history.title') },
+        ]}
+      />
+      <h1 className="mt-2 text-2xl font-bold text-coach-text [font-family:var(--font-family-heading)]">
+        {t('coach.history.title')}
+      </h1>
+
+      {isLoading && (
+        <div className="flex justify-center py-10">
+          <CircularProgress size={24} />
+        </div>
+      )}
+
+      {!isLoading && conversations.length === 0 && (
+        <p className="mt-8 text-center text-sm text-coach-text-muted">{t('coach.history.empty')}</p>
+      )}
+
+      <div className="mt-4 flex flex-col gap-2">
+        {conversations.map((conversation) => (
+          <button
+            key={conversation.id}
+            onClick={() => navigate(`${APP_ROUTES.COACH_HISTORY}/${conversation.id}`)}
+            className="flex items-center gap-3 rounded-xl border border-coach-border bg-coach-surface px-4 py-3 text-left transition-colors hover:bg-coach-bg"
+          >
+            <LuMessageCircle size={18} className="shrink-0 text-coach-primary" />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium text-coach-text">
+                  {new Date(conversation.startedAt).toLocaleString()}
+                </span>
+                <span className="shrink-0 text-xs text-coach-text-muted">
+                  {t(STATUS_LABEL_KEY[conversation.status])}
+                </span>
+              </div>
+              <p className="mt-1 truncate text-xs text-coach-text-muted">
+                {conversation.summary || t('coach.history.noSummary')}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {hasNextPage && (
+        <div className="mt-4 flex justify-center">
+          <Button variant="secondary" size="sm" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+            {isFetchingNextPage ? <CircularProgress size={14} /> : t('entriesPage.loadMore')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CoachHistoryListPage;

--- a/src/pages/EntriesPage/EntriesListPage/EntriesListPage.tsx
+++ b/src/pages/EntriesPage/EntriesListPage/EntriesListPage.tsx
@@ -1,17 +1,21 @@
 import { CircularProgress } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { LuPenLine, LuSearch } from 'react-icons/lu';
 import { useAuth } from '../../../providers/AuthProvider';
 import { useSnackbar } from '../../../providers/SnackbarProvider';
 import { useEntriesInfiniteQuery } from '../../../queries/entriesQueryHook';
+import { useSavedFrameworkEntriesInfiniteQuery } from '../../../queries/savedFrameworkEntriesQueryHook';
 import type { Entry } from '../../../models/entry';
 import EntryCard from '../components/EntryCard/EntryCard';
+import SavedFrameworkEntryCard from '../components/SavedFrameworkEntryCard/SavedFrameworkEntryCard';
 import Breadcrumb from '../../../components/Breadcrumb/Breadcrumb';
 import { Button } from '../../../components/Button/Button';
 import { APP_ROUTES } from '../../../constants/route';
 import './EntriesListPage.scss';
+
+type EntriesTab = 'entries' | 'insights';
 
 type TimeFilter = 'all' | 'today' | 'week' | 'month' | 'year';
 
@@ -58,9 +62,12 @@ const EntriesListPage: React.FC = () => {
   const { showSnackbar } = useSnackbar();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const highlightId = searchParams.get('highlight');
 
   const [activeFilter, setActiveFilter] = useState<TimeFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [activeTab, setActiveTab] = useState<EntriesTab>(highlightId ? 'insights' : 'entries');
 
   const {
     data,
@@ -71,6 +78,14 @@ const EntriesListPage: React.FC = () => {
     isFetchingNextPage
   } = useEntriesInfiniteQuery();
 
+  const {
+    data: savedEntriesData,
+    isLoading: isSavedEntriesLoading,
+    fetchNextPage: fetchNextSavedEntriesPage,
+    hasNextPage: hasNextSavedEntriesPage,
+    isFetchingNextPage: isFetchingNextSavedEntriesPage,
+  } = useSavedFrameworkEntriesInfiniteQuery();
+
   useEffect(() => {
     if (isError) {
       showSnackbar('Failed to load entries', 'error');
@@ -80,6 +95,16 @@ const EntriesListPage: React.FC = () => {
   const entries = useMemo(() => {
     return data?.pages.flatMap(page => page.content) || [];
   }, [data]);
+
+  const savedEntries = useMemo(() => {
+    return savedEntriesData?.pages.flatMap(page => page.content) || [];
+  }, [savedEntriesData]);
+
+  useEffect(() => {
+    if (!highlightId || activeTab !== 'insights') return;
+    const el = document.getElementById(`saved-entry-${highlightId}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [highlightId, activeTab, savedEntries]);
 
   const total = data?.pages[0]?.total || 0;
 
@@ -122,8 +147,26 @@ const EntriesListPage: React.FC = () => {
       {/* Content */}
       <div className="entries-page__content">
 
+        {/* Tabs: manual journal entries vs saved framework entries captured from Aura chats */}
+        {currentUser && (
+          <div className="entries-page__filters">
+            <button
+              className={`entries-page__filter-pill ${activeTab === 'entries' ? 'entries-page__filter-pill--active' : ''}`}
+              onClick={() => setActiveTab('entries')}
+            >
+              {t('entriesPage.tabEntries')}
+            </button>
+            <button
+              className={`entries-page__filter-pill ${activeTab === 'insights' ? 'entries-page__filter-pill--active' : ''}`}
+              onClick={() => setActiveTab('insights')}
+            >
+              {t('entriesPage.tabInsights')}
+            </button>
+          </div>
+        )}
+
         {/* Filter toolbar + search */}
-        {currentUser && entries.length > 0 && (
+        {activeTab === 'entries' && currentUser && entries.length > 0 && (
           <div className="entries-page__toolbar">
             <div className="entries-page__filters">
               {FILTER_KEYS.map((key) => (
@@ -150,7 +193,7 @@ const EntriesListPage: React.FC = () => {
         )}
 
         {/* Not logged in */}
-        {!currentUser && !isLoading && (
+        {activeTab === 'entries' && !currentUser && !isLoading && (
           <div className="entries-page__empty">
             <p className="entries-page__empty-title">{t('entriesPage.loginRequired')}</p>
             <p className="entries-page__empty-hint">{t('entriesPage.loginRequiredHint')}</p>
@@ -158,7 +201,7 @@ const EntriesListPage: React.FC = () => {
         )}
 
         {/* Logged in but no entries at all */}
-        {currentUser && !isLoading && entries.length === 0 && (
+        {activeTab === 'entries' && currentUser && !isLoading && entries.length === 0 && (
           <div className="entries-page__empty">
             <p className="entries-page__empty-title">{t('entriesPage.emptyState')}</p>
             <p className="entries-page__empty-hint">{t('entriesPage.emptyStateHint')}</p>
@@ -176,14 +219,14 @@ const EntriesListPage: React.FC = () => {
         )}
 
         {/* No results after filter/search */}
-        {currentUser && !isLoading && entries.length > 0 && filteredEntries.length === 0 && (
+        {activeTab === 'entries' && currentUser && !isLoading && entries.length > 0 && filteredEntries.length === 0 && (
           <div className="entries-page__empty">
             <p className="entries-page__empty-hint">{t('entriesPage.noResults')}</p>
           </div>
         )}
 
         {/* Calendar grid */}
-        {filteredEntries.length > 0 && (
+        {activeTab === 'entries' && filteredEntries.length > 0 && (
           <div className="entries-page__grid">
             {filteredEntries.map((entry) => (
               <EntryCard key={entry.id} entry={entry} />
@@ -192,6 +235,7 @@ const EntriesListPage: React.FC = () => {
         )}
 
         {/* Load more */}
+        {activeTab === 'entries' && (
         <div className="entries-page__load-more">
           {(isFetchingNextPage || isLoading) && (<CircularProgress size={24} sx={{ mb: 1 }} />)}
 
@@ -213,6 +257,54 @@ const EntriesListPage: React.FC = () => {
             </span>
           )}
         </div>
+        )}
+
+        {/* Insights tab: framework entries captured from Aura chats (Free-form, Johari Window, ...) */}
+        {activeTab === 'insights' && (
+          <>
+            {!isSavedEntriesLoading && savedEntries.length === 0 && (
+              <div className="entries-page__empty">
+                <p className="entries-page__empty-title">{t('entriesPage.insightsEmpty')}</p>
+                <p className="entries-page__empty-hint">{t('entriesPage.insightsEmptyHint')}</p>
+                <Button
+                  variant="primary"
+                  size="md"
+                  shape="pill"
+                  className="mt-4"
+                  onClick={() => navigate(APP_ROUTES.COACH_CHAT)}
+                >
+                  <span>{t('entriesPage.goChatWithAura')}</span>
+                </Button>
+              </div>
+            )}
+
+            {savedEntries.length > 0 && (
+              <div className="entries-page__grid">
+                {savedEntries.map((entry) => (
+                  <SavedFrameworkEntryCard key={entry.id} entry={entry} highlighted={entry.id === highlightId} />
+                ))}
+              </div>
+            )}
+
+            <div className="entries-page__load-more">
+              {(isFetchingNextSavedEntriesPage || isSavedEntriesLoading) && (
+                <CircularProgress size={24} sx={{ mb: 1 }} />
+              )}
+
+              {!isSavedEntriesLoading && hasNextSavedEntriesPage && (
+                <Button
+                  variant="secondary"
+                  size="md"
+                  shape="pill"
+                  onClick={() => fetchNextSavedEntriesPage()}
+                  className="!border-white/20 !bg-transparent !text-coach-bg hover:!bg-white/10"
+                >
+                  {t('entriesPage.loadMore')}
+                </Button>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/EntriesPage/components/SavedFrameworkEntryCard/SavedFrameworkEntryCard.tsx
+++ b/src/pages/EntriesPage/components/SavedFrameworkEntryCard/SavedFrameworkEntryCard.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { FrameworkType, SavedFrameworkEntry } from '../../../../models/savedFrameworkEntry';
+import FrameworkEntryForm from '../../../../components/InsightCatcher/FrameworkEntryForm';
+import { useUpdateSavedFrameworkEntryMutation } from '../../../../queries/savedFrameworkEntriesQueryHook';
+import { useSnackbar } from '../../../../providers/SnackbarProvider';
+
+interface SavedFrameworkEntryCardProps {
+  entry: SavedFrameworkEntry;
+  highlighted?: boolean;
+}
+
+const FRAMEWORK_LABEL_KEY: Record<FrameworkType, string> = {
+  FREEFORM: 'insightCatcher.freeformLabel',
+  JOHARI_WINDOW: 'insightCatcher.johariWindowLabel',
+  ACT_MATRIX: 'insightCatcher.actMatrix',
+  PERSONAL_SWOT: 'insightCatcher.personalSwot',
+  LIFE_POSITIONS: 'insightCatcher.lifePositions',
+};
+
+const firstNonEmpty = (payload: Record<string, unknown>, keys: string[]): string => {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return '';
+};
+
+const buildSnippet = (entry: SavedFrameworkEntry): string => {
+  const payload = entry.payload as Record<string, unknown>;
+  switch (entry.frameworkType) {
+    case 'FREEFORM':
+      return firstNonEmpty(payload, ['content']);
+    case 'JOHARI_WINDOW':
+      return firstNonEmpty(payload, ['open', 'hidden']);
+    case 'ACT_MATRIX':
+      return firstNonEmpty(payload, ['values', 'towardMoves']);
+    case 'PERSONAL_SWOT':
+      return firstNonEmpty(payload, ['strengths', 'weaknesses']);
+    case 'LIFE_POSITIONS':
+      return firstNonEmpty(payload, ['notes']);
+    default:
+      return '';
+  }
+};
+
+/** Card for a saved framework entry on "Đúc kết" — click "Sửa" to edit in place using the same
+ * form used to create it from the Aura chat's Insight Catcher panel. */
+const SavedFrameworkEntryCard = ({ entry, highlighted }: SavedFrameworkEntryCardProps) => {
+  const { t } = useTranslation();
+  const { showSnackbar } = useSnackbar();
+  const [isEditing, setIsEditing] = useState(false);
+  const updateEntry = useUpdateSavedFrameworkEntryMutation();
+
+  const handleUpdate = async (title: string | undefined, payload: Record<string, unknown>, personId?: string) => {
+    await updateEntry.mutateAsync({ id: entry.id, title, payload, personId });
+    setIsEditing(false);
+    showSnackbar(t('insightCatcher.updateSuccess'), 'success');
+  };
+
+  if (isEditing) {
+    // Light card deliberately, styled the same as the create-flow form on the Coach page (the
+    // coach-* palette has no dark-theme variant) — reads as a popover against the dark
+    // "Đúc kết" background rather than blending into the page.
+    return (
+      <div id={`saved-entry-${entry.id}`} className="rounded-xl border border-coach-border bg-coach-surface p-4 shadow-lg">
+        <FrameworkEntryForm
+          frameworkType={entry.frameworkType}
+          initialTitle={entry.title}
+          initialPayload={entry.payload}
+          initialPersonId={entry.personId}
+          onSubmit={handleUpdate}
+          onCancel={() => setIsEditing(false)}
+          submitLabel={t('insightCatcher.saveChanges')}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      id={`saved-entry-${entry.id}`}
+      className={`rounded-xl border p-4 transition-colors ${
+        highlighted
+          ? 'border-violet-400/60 bg-[rgba(30,41,59,0.75)] ring-2 ring-violet-400/40'
+          : 'border-white/10 bg-[rgba(30,41,59,0.55)] hover:bg-[rgba(30,41,59,0.75)]'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px] font-medium text-slate-300">
+          {t(FRAMEWORK_LABEL_KEY[entry.frameworkType])}
+        </span>
+        <button onClick={() => setIsEditing(true)} className="text-xs text-violet-300 hover:underline">
+          {t('insightCatcher.edit')}
+        </button>
+      </div>
+      {entry.title && <p className="mt-2 text-sm font-semibold text-slate-100">{entry.title}</p>}
+      {entry.personName && (
+        <p className="mt-1 text-xs text-violet-300">{t('insightCatcher.lifePositionsForm.about', { name: entry.personName })}</p>
+      )}
+      <p className="mt-1 line-clamp-3 text-sm text-slate-400">{buildSnippet(entry)}</p>
+      <p className="mt-2 text-[11px] text-slate-500">{new Date(entry.createdAt).toLocaleDateString()}</p>
+    </div>
+  );
+};
+
+export default SavedFrameworkEntryCard;

--- a/src/queries/conversationsQueryHook.ts
+++ b/src/queries/conversationsQueryHook.ts
@@ -1,4 +1,6 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query';
+import type { PaginatedResponse } from '../models/base';
+import type { Conversation } from '../models/conversation';
 import { conversationsService } from '../services/conversationsService';
 
 export const useConversationQuery = (id?: string) => {
@@ -6,6 +8,33 @@ export const useConversationQuery = (id?: string) => {
     queryKey: ['conversations', id],
     queryFn: () => conversationsService.getConversation(id!),
     enabled: !!id,
+  });
+};
+
+export const useConversationsInfiniteQuery = () => {
+  return useInfiniteQuery<
+    PaginatedResponse<Conversation>,
+    Error,
+    InfiniteData<PaginatedResponse<Conversation>>,
+    string[],
+    string | null
+  >({
+    queryKey: ['conversations', 'list'],
+    initialPageParam: null,
+    staleTime: 1000 * 60 * 5,
+
+    queryFn: async ({ pageParam }) => {
+      const nextLink = pageParam as string | undefined;
+      const response = await conversationsService.getConversations(nextLink);
+      return {
+        ...response,
+        content: response.content || [],
+        nextLink: response.nextLink || null,
+        total: response.total || 0,
+      };
+    },
+
+    getNextPageParam: (lastPage) => lastPage.nextLink || undefined,
   });
 };
 
@@ -33,8 +62,15 @@ export const useEndConversationMutation = () => {
     mutationFn: (conversationId: string) => conversationsService.endConversation(conversationId),
     onSuccess: (_data, conversationId) => {
       queryClient.invalidateQueries({ queryKey: ['conversations', conversationId] });
+      queryClient.invalidateQueries({ queryKey: ['conversations', 'list'] });
       queryClient.invalidateQueries({ queryKey: ['people'] });
       queryClient.invalidateQueries({ queryKey: ['insights'] });
     },
+  });
+};
+
+export const useSummarizeConversationMutation = () => {
+  return useMutation({
+    mutationFn: (conversationId: string) => conversationsService.summarizeConversation(conversationId),
   });
 };

--- a/src/queries/insightsQueryHook.ts
+++ b/src/queries/insightsQueryHook.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, type InfiniteData } from '@tanstack/react-query';
 import type { PaginatedResponse } from '../models/base';
 import type { Insight } from '../models/insight';
 import { insightsService } from '../services/insightsService';
@@ -27,5 +27,16 @@ export const useInsightsInfiniteQuery = () => {
     },
 
     getNextPageParam: (lastPage) => lastPage.nextLink || undefined,
+  });
+};
+
+/** Insights linked to one specific person — powers the "insight liên quan" list on the
+ * RelationshipMap person detail panel (see [[project-mimose-pivot]] Phase 2). */
+export const usePersonInsightsQuery = (personId: string | null) => {
+  return useQuery({
+    queryKey: ['insights', 'byPerson', personId],
+    queryFn: () => insightsService.getInsightsForPerson(personId!),
+    enabled: !!personId,
+    staleTime: 1000 * 60,
   });
 };

--- a/src/queries/savedFrameworkEntriesQueryHook.ts
+++ b/src/queries/savedFrameworkEntriesQueryHook.ts
@@ -1,0 +1,68 @@
+import { useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from '@tanstack/react-query';
+import type {
+  CreateSavedFrameworkEntryRequest,
+  SavedFrameworkEntry,
+  UpdateSavedFrameworkEntryRequest,
+} from '../models/savedFrameworkEntry';
+import type { PaginatedResponse } from '../models/base';
+import { savedFrameworkEntriesService } from '../services/savedFrameworkEntriesService';
+
+export const useSavedFrameworkEntriesInfiniteQuery = () => {
+  return useInfiniteQuery<
+    PaginatedResponse<SavedFrameworkEntry>,
+    Error,
+    InfiniteData<PaginatedResponse<SavedFrameworkEntry>>,
+    string[],
+    string | null
+  >({
+    queryKey: ['savedFrameworkEntries'],
+    initialPageParam: null,
+    staleTime: 1000 * 60 * 5,
+
+    queryFn: async ({ pageParam }) => {
+      const nextLink = pageParam as string | undefined;
+      const response = await savedFrameworkEntriesService.getEntries(nextLink);
+      return {
+        ...response,
+        content: response.content || [],
+        nextLink: response.nextLink || null,
+        total: response.total || 0,
+      };
+    },
+
+    getNextPageParam: (lastPage) => lastPage.nextLink || undefined,
+  });
+};
+
+export const useCreateSavedFrameworkEntryMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (entry: CreateSavedFrameworkEntryRequest) => savedFrameworkEntriesService.createEntry(entry),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ['savedFrameworkEntries'] });
+    },
+  });
+};
+
+export const useUpdateSavedFrameworkEntryMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (entry: UpdateSavedFrameworkEntryRequest) => savedFrameworkEntriesService.updateEntry(entry),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ['savedFrameworkEntries'] });
+    },
+  });
+};
+
+export const useDeleteSavedFrameworkEntryMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => savedFrameworkEntriesService.deleteEntry(id),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ['savedFrameworkEntries'] });
+    },
+  });
+};

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -13,6 +13,8 @@ const ProfilePage = lazy(() => import('../pages/ProfilePage/ProfilePage'));
 const MimoLandingPage = lazy(() => import('../pages/MimoLandingPage/MimoLandingPage'));
 const SignupPage = lazy(() => import('../pages/SignupPage/SignupPage'));
 const CoachChatPage = lazy(() => import('../pages/CoachChatPage/CoachChatPage'));
+const CoachHistoryListPage = lazy(() => import('../pages/CoachHistoryPage/CoachHistoryListPage'));
+const CoachHistoryDetailPage = lazy(() => import('../pages/CoachHistoryPage/CoachHistoryDetailPage'));
 const DashboardPage = lazy(() => import('../pages/DashboardPage/DashboardPage'));
 const OnboardingPage = lazy(() => import('../pages/OnboardingPage/OnboardingPage'));
 
@@ -31,6 +33,16 @@ export const AppRoutes = () => {
                 <Route path={APP_ROUTES.COACH_CHAT} element={
                     <ProtectedRoute>
                         <CoachChatPage />
+                    </ProtectedRoute>
+                } />
+                <Route path={APP_ROUTES.COACH_HISTORY} element={
+                    <ProtectedRoute>
+                        <CoachHistoryListPage />
+                    </ProtectedRoute>
+                } />
+                <Route path={APP_ROUTES.COACH_HISTORY_DETAIL} element={
+                    <ProtectedRoute>
+                        <CoachHistoryDetailPage />
                     </ProtectedRoute>
                 } />
                 <Route path={APP_ROUTES.DASHBOARD} element={

--- a/src/services/conversationsService.ts
+++ b/src/services/conversationsService.ts
@@ -1,3 +1,4 @@
+import type { PaginatedResponse } from '../models/base';
 import type { Conversation, ConversationMessage } from '../models/conversation';
 import axiosInstance from './axiosSetup';
 
@@ -7,8 +8,19 @@ export const conversationsService = {
     return data;
   },
 
+  async getConversations(url?: string | null): Promise<PaginatedResponse<Conversation>> {
+    const requestUrl = url || '/conversations?page=0&size=10';
+    const { data } = await axiosInstance.get<PaginatedResponse<Conversation>>(requestUrl);
+    return data;
+  },
+
   async getConversation(id: string): Promise<Conversation> {
     const { data } = await axiosInstance.get<Conversation>(`/conversations/${id}`);
+    return data;
+  },
+
+  async summarizeConversation(id: string): Promise<Conversation> {
+    const { data } = await axiosInstance.post<Conversation>(`/conversations/${id}/summarize`);
     return data;
   },
 

--- a/src/services/insightsService.ts
+++ b/src/services/insightsService.ts
@@ -8,4 +8,11 @@ export const insightsService = {
     const { data } = await axiosInstance.get<PaginatedResponse<Insight>>(requestUrl);
     return data;
   },
+
+  async getInsightsForPerson(personId: string): Promise<PaginatedResponse<Insight>> {
+    const { data } = await axiosInstance.get<PaginatedResponse<Insight>>('/insights', {
+      params: { personId, page: 0, size: 20 },
+    });
+    return data;
+  },
 };

--- a/src/services/savedFrameworkEntriesService.ts
+++ b/src/services/savedFrameworkEntriesService.ts
@@ -1,0 +1,35 @@
+import type { PaginatedResponse } from '../models/base';
+import type {
+  CreateSavedFrameworkEntryRequest,
+  SavedFrameworkEntry,
+  UpdateSavedFrameworkEntryRequest,
+} from '../models/savedFrameworkEntry';
+import axiosInstance from './axiosSetup';
+
+export const savedFrameworkEntriesService = {
+  async getEntries(url?: string | null): Promise<PaginatedResponse<SavedFrameworkEntry>> {
+    const requestUrl = url || '/saved-framework-entries?page=0&size=10';
+    const { data } = await axiosInstance.get<PaginatedResponse<SavedFrameworkEntry>>(requestUrl);
+    return data;
+  },
+
+  async getEntry(id: string): Promise<SavedFrameworkEntry> {
+    const { data } = await axiosInstance.get<SavedFrameworkEntry>(`/saved-framework-entries/${id}`);
+    return data;
+  },
+
+  async createEntry(entry: CreateSavedFrameworkEntryRequest): Promise<SavedFrameworkEntry> {
+    const { data } = await axiosInstance.post<SavedFrameworkEntry>('/saved-framework-entries', entry);
+    return data;
+  },
+
+  async updateEntry(entry: UpdateSavedFrameworkEntryRequest): Promise<SavedFrameworkEntry> {
+    const { id, ...updateData } = entry;
+    const { data } = await axiosInstance.put<SavedFrameworkEntry>(`/saved-framework-entries/${id}`, updateData);
+    return data;
+  },
+
+  async deleteEntry(id: string): Promise<void> {
+    await axiosInstance.delete(`/saved-framework-entries/${id}`);
+  },
+};


### PR DESCRIPTION
## Summary
Frontend for the Aura chat upgrade — fixes real gaps found after using the AI Coach chat, plus a new Insight Catcher for deliberately saving structured insights during a conversation.

- **Chat persistence**: refreshing no longer loses the conversation (resumes an ACTIVE session instead of always starting a new one).
- **Chat history**: session list + read-only transcript view, reachable from the Coach page header.
- **Markdown rendering**: Aura's replies render as real markdown (bold/lists/etc.) instead of raw `**`/`-` text.
- **Session summary**: "Tóm tắt" button, summary card connects to the save flow — opening "Log tự do" right after pre-fills the content with the summary.
- **Insight Catcher panel**: capture Free-form, Johari Window, ACT Matrix, Personal SWOT, and Life Positions insights, or quick add/update a person (PRM), all as described cards (not bare buttons) using the app's existing terminology.
- **Đúc kết / Thấu hiểu**: saved entries shown + editable on Đúc kết with redirect-and-highlight after saving; insights linked to a person show up on the relationship map.
- **i18n**: full vi/en coverage for everything this feature touches (verified 0 key mismatches between locales).
- Bugfix: `PersonForm`'s side-by-side name+relationship-type row overflowed the narrow (320px) Insight Catcher panel — now stacked/full-width.

Depends on [reflectly-be#20](https://github.com/hankimthuy/reflectly-be/pull/20) (deploy backend first).

## Testing
- `tsc --noEmit`, `eslint`, `vite build` all pass.
- Manually verified end-to-end in the Browser pane against a live dev backend: every framework type saved and rendered correctly, PRM add/update, EN/VI language switch showed no leaked translation keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)