### PR TITLE
feat(security): surface backend anti-abuse limits in the UI

### DIFF
--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -2,6 +2,9 @@ import { useRef, useState, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '../Button/Button';
 
+/** Mirrors the backend's SendMessageRequestDto @Size(max = 4000) cap. */
+const MAX_MESSAGE_LENGTH = 4000;
+
 interface MessageInputProps {
   onSend: (content: string) => void;
   disabled?: boolean;
@@ -46,6 +49,7 @@ const MessageInput = ({ onSend, disabled }: MessageInputProps) => {
         onKeyDown={handleKeyDown}
         disabled={disabled}
         rows={1}
+        maxLength={MAX_MESSAGE_LENGTH}
         placeholder={t('coach.inputPlaceholder') as string}
         className="max-h-32 flex-1 resize-none overflow-y-auto rounded-xl border border-coach-border bg-coach-bg px-3 py-2 text-sm text-coach-text outline-none focus:border-coach-primary disabled:opacity-50"
       />

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -48,6 +48,9 @@
     "endSession": "Kết thúc phiên",
     "emptyState": "Bạn cứ thoải mái bắt đầu — chia sẻ điều đang ở trong đầu bạn lúc này, mình ở đây để lắng nghe.",
     "sendError": "Không thể gửi tin nhắn lúc này. Vui lòng thử lại.",
+    "startError": "Không thể bắt đầu phiên trò chuyện lúc này. Vui lòng thử lại sau.",
+    "quotaExceeded": "Bạn đã dùng hết lượt trò chuyện thử nghiệm với Aura trong giai đoạn này. Cảm ơn bạn đã quan tâm — hãy quay lại sau nhé!",
+    "backToDashboard": "Quay lại Dashboard",
     "summarize": "Tóm tắt",
     "summarizing": "Đang tóm tắt...",
     "summarizeError": "Không thể tóm tắt lúc này. Vui lòng thử lại.",
@@ -195,6 +198,7 @@
     "description": "Khám phá bản thân qua từng cuộc hội thoại. Bản đồ insight và các mối quan hệ được cá nhân hóa từ chính những chia sẻ của bạn.",
     "tagline": "Trò chuyện để thấu hiểu chính mình, mỗi ngày.",
     "footer": "© 2026 Aura Self AI. Đồng hành cùng hành trình Thấu hiểu & Lãnh đạo Bản thân.",
+    "contactLink": "Liên hệ tác giả",
     "welcome": "Chào mừng bạn quay lại với Aura Self AI.",
     "ctaLoggedOut": "Bắt đầu trò chuyện với Coach",
     "ctaLoggedIn": "Tiếp tục trò chuyện"

--- a/src/pages/CoachChatPage/CoachChatPage.tsx
+++ b/src/pages/CoachChatPage/CoachChatPage.tsx
@@ -27,6 +27,7 @@ const CoachChatPage = () => {
   const [isStarting, setIsStarting] = useState(true);
   const [messages, setMessages] = useState<ConversationMessage[]>([]);
   const [latestSummary, setLatestSummary] = useState<string | null>(null);
+  const [startError, setStartError] = useState<string | null>(null);
   const hasStartedRef = useRef(false);
   const lastHandledReplyIdRef = useRef<string | null>(null);
 
@@ -62,12 +63,23 @@ const CoachChatPage = () => {
         localStorage.removeItem(ACTIVE_CONVERSATION_KEY);
       }
 
-      const conversation = await conversationsService.startConversation();
-      localStorage.setItem(ACTIVE_CONVERSATION_KEY, conversation.id);
-      setConversationId(conversation.id);
+      try {
+        const conversation = await conversationsService.startConversation();
+        localStorage.setItem(ACTIVE_CONVERSATION_KEY, conversation.id);
+        setConversationId(conversation.id);
+      } catch (error) {
+        const status = (error as { response?: { status?: number } })?.response?.status;
+        const serverMessage = (error as { response?: { data?: { message?: string } } })?.response?.data?.message;
+        setStartError(
+          status === 429
+            ? serverMessage || t('coach.quotaExceeded')
+            : t('coach.startError'),
+        );
+      }
     };
 
     resume().finally(() => setIsStarting(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -191,21 +203,32 @@ const CoachChatPage = () => {
           )}
         </div>
 
-        {messages.length === 0 && !isStarting && (
-          <div className="flex flex-1 items-center justify-center px-8 text-center text-sm text-coach-text-muted">
-            {t('coach.emptyState')}
+        {startError ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+            <p className="text-sm text-coach-text">{startError}</p>
+            <Button variant="secondary" size="sm" onClick={() => navigate(APP_ROUTES.DASHBOARD)}>
+              {t('coach.backToDashboard')}
+            </Button>
           </div>
+        ) : (
+          <>
+            {messages.length === 0 && !isStarting && (
+              <div className="flex flex-1 items-center justify-center px-8 text-center text-sm text-coach-text-muted">
+                {t('coach.emptyState')}
+              </div>
+            )}
+
+            {sendMessage.isError && (
+              <p className="px-4 pb-1 text-center text-xs text-red-500">
+                {t('coach.sendError')}
+              </p>
+            )}
+
+            <MessageList messages={messages} isThinking={sendMessage.isPending || isStarting} />
+
+            <MessageInput onSend={handleSend} disabled={!conversationId || sendMessage.isPending} />
+          </>
         )}
-
-        {sendMessage.isError && (
-          <p className="px-4 pb-1 text-center text-xs text-red-500">
-            {t('coach.sendError')}
-          </p>
-        )}
-
-        <MessageList messages={messages} isThinking={sendMessage.isPending || isStarting} />
-
-        <MessageInput onSend={handleSend} disabled={!conversationId || sendMessage.isPending} />
       </div>
 
       <div className="w-full shrink-0 border-t border-coach-border bg-coach-surface lg:h-auto lg:w-80 lg:overflow-y-auto lg:rounded-2xl lg:border lg:border-t lg:border-coach-border">

--- a/src/pages/MimoLandingPage/MimoLandingPage.scss
+++ b/src/pages/MimoLandingPage/MimoLandingPage.scss
@@ -13,12 +13,26 @@
 }
 
 .footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs, 4px);
   color: var(--color-coach-text-muted);
   padding: var(--spacing-xl) var(--spacing-md);
   text-align: center;
   font-size: var(--font-size-sm);
   font-weight: 500;
   margin-bottom: 16px;
+
+  &__contact-link {
+    color: var(--color-coach-primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
 
   @include mobile-only {
     display: none;

--- a/src/pages/MimoLandingPage/MimoLandingPage.tsx
+++ b/src/pages/MimoLandingPage/MimoLandingPage.tsx
@@ -12,6 +12,14 @@ const MimoLandingPage = () => {
       <HomeValueSections />
       <footer className="footer">
         <span>{t('brand.footer')}</span>
+        <a
+          className="footer__contact-link"
+          href="https://hankimthuy.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('brand.contactLink')}
+        </a>
       </footer>
     </div>
   );

--- a/src/providers/SnackbarProvider.tsx
+++ b/src/providers/SnackbarProvider.tsx
@@ -1,5 +1,6 @@
-import React, { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
 import SnackbarComponent, { type SnackbarType } from '../components/Snackbar/Snackbar';
+import { RATE_LIMITED_EVENT } from '../services/axiosSetup';
 
 interface SnackbarContextValue {
   showSnackbar: (message: string, type: SnackbarType, duration?: number, title?: string) => void;
@@ -37,6 +38,17 @@ export const SnackbarProvider: React.FC<{ children: ReactNode }> = ({ children }
   const handleClose = useCallback(() => {
     setSnackbar((prev) => ({ ...prev, open: false }));
   }, []);
+
+  // Surfaces 429 (rate-limit/quota) responses from any API call app-wide — axiosSetup dispatches
+  // this as a plain DOM event since it has no React context of its own to call showSnackbar from.
+  useEffect(() => {
+    const handleRateLimited = (event: Event) => {
+      const detail = (event as CustomEvent<{ message: string }>).detail;
+      showSnackbar(detail.message, 'warning', 6000);
+    };
+    window.addEventListener(RATE_LIMITED_EVENT, handleRateLimited);
+    return () => window.removeEventListener(RATE_LIMITED_EVENT, handleRateLimited);
+  }, [showSnackbar]);
 
   return (
     <SnackbarContext.Provider value={{ showSnackbar }}>

--- a/src/services/axiosSetup.ts
+++ b/src/services/axiosSetup.ts
@@ -14,6 +14,19 @@ const axiosInstance = axios.create({
 let isRedirecting = false;
 const REDIRECT_DEBOUNCE_MS = 2000;
 
+/** Dispatched app-wide on 429 (quota/rate-limit) so any mounted listener (see SnackbarProvider)
+ * can surface it without axiosSetup needing to depend on React. */
+export const RATE_LIMITED_EVENT = 'api:rate-limited';
+
+const DEFAULT_RATE_LIMIT_MESSAGE = 'Bạn đang thao tác quá nhanh hoặc đã dùng hết lượt cho phép. Vui lòng thử lại sau.';
+
+const handleRateLimitedError = (error: unknown): void => {
+    const message =
+        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        DEFAULT_RATE_LIMIT_MESSAGE;
+    window.dispatchEvent(new CustomEvent(RATE_LIMITED_EVENT, { detail: { message } }));
+};
+
 const handleUnauthorizedError = (): void => {
     if (isRedirecting) {
         return;
@@ -52,6 +65,10 @@ axiosInstance.interceptors.response.use(
     (error) => {
         if (error.response?.status === 401) {
             handleUnauthorizedError();
+        }
+
+        if (error.response?.status === 429) {
+            handleRateLimitedError(error);
         }
 
         return Promise.reject(error);


### PR DESCRIPTION
## Bối cảnh
Đi kèm PR backend "bound Gemini API abuse before public launch" (rate-limit + quota + Google-only login ở prod). PR này chỉ thêm phần UI để những giới hạn đó không tạo ra trải nghiệm vỡ (blank chat, lỗi im lặng) và thêm kênh liên hệ cho người lạ ghé web.

## Thay đổi
- `axiosSetup.ts`: bắt response 429 (rate-limit/quota), phát `RATE_LIMITED_EVENT`; `SnackbarProvider` lắng nghe và hiện toast cảnh báo app-wide.
- `CoachChatPage`: nếu `startConversation` bị chặn do hết quota, hiện màn hình thông báo riêng + nút quay lại Dashboard, thay vì màn chat trống không hoạt động được.
- `MessageInput`: `maxLength={4000}`, khớp với `SendMessageRequestDto` `@Size(max = 4000)` sẵn có ở backend.
- Footer landing page (`MimoLandingPage`): thêm link "Liên hệ tác giả" → `hankimthuy.com`, cho người tìm ra web có cách liên hệ mà không lộ email cá nhân.

## Env vars
Không có env var mới ở FE. Không cần đổi gì thêm ngoài phần backend.

## Verification
- `npm run build` (tsc + vite): xanh.
- `npm run test -- --run`: 106/106 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)